### PR TITLE
feat: add tailwind typing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      # testing
+      - alpha
 jobs:
   release:
     name: Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloom-housing/ui-components",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "author": "Sean Albert <sean.albert@exygy.com>",
   "description": "Shared user interface components for Bloom affordable housing system",
   "homepage": "https://github.com/bloom-housing/ui-components",
@@ -13,13 +13,18 @@
   },
   "release": {
     "branches": [
-      "main"
+      "main",
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
     ]
   },
   "files": [
     "dist",
     "src",
     "tailwind.config.js",
+    "tailwind.config.d.ts",
     "tailwind.tosass.js",
     "index.ts"
   ],
@@ -108,6 +113,15 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@mapbox/mapbox-sdk": "^0.13.0",
+    "@types/jwt-decode": "^2.2.1",
+    "@types/markdown-to-jsx": "^6.11.2",
+    "@types/mdx": "^2.0.1",
+    "@types/node": "^12.12.67",
+    "@types/node-polyglot": "^2.4.1",
+    "@types/react-beautiful-dnd": "^13.1.1",
+    "@types/react-dom": "^16.9.5",
+    "@types/react-text-mask": "^5.4.6",
+    "@types/react-transition-group": "^4.4.0",
     "ag-grid-community": "^26.0.0",
     "ag-grid-react": "^26.0.0",
     "aria-autocomplete": "^1.4.0",

--- a/tailwind.config.d.ts
+++ b/tailwind.config.d.ts
@@ -1,0 +1,122 @@
+export const important: boolean;
+export const purge: boolean;
+export namespace theme {
+    const screens: {
+        sm: string;
+        md: string;
+        lg: string;
+        xl: string;
+        "2xl": string;
+        print: {
+            raw: string;
+        };
+    };
+    const fontSize: {
+        "2xs": string;
+        xs: string;
+        sm: string;
+        tiny: string;
+        base: string;
+        "base-alt": string;
+        lg: string;
+        xl: string;
+        "2xl": string;
+        "3xl": string;
+        "4xl": string;
+        "5xl": string;
+        "6xl": string;
+        "6.5xl": string;
+        "7xl": string;
+    };
+    const fontFamily: {
+        sans: string;
+        serif: string;
+        "alt-sans": string;
+    };
+    const colors: {
+        primary: string;
+        "primary-dark": string;
+        "primary-darker": string;
+        "primary-light": string;
+        "primary-lighter": string;
+        secondary: string;
+        alert: string;
+        "alert-light": string;
+        "alert-dark": string;
+        success: string;
+        "success-light": string;
+        "success-dark": string;
+        warn: string;
+        "warn-light": string;
+        "warn-dark": string;
+        "accent-cool": string;
+        "accent-cool-light": string;
+        "accent-cool-dark": string;
+        "accent-warm": string;
+        "accent-warm-dark": string;
+        "accent-warm-light": string;
+        "accent-warm-lighter": string;
+        lush: string;
+        white: string;
+        black: string;
+        blue: {
+            800: string;
+            700: string;
+            600: string;
+            300: string;
+            200: string;
+        };
+        red: {
+            700: string;
+            300: string;
+        };
+        yellow: {
+            700: string;
+            300: string;
+        };
+        green: {
+            700: string;
+            300: string;
+        };
+        teal: {
+            700: string;
+            300: string;
+        };
+        gray: {
+            950: string;
+            900: string;
+            850: string;
+            800: string;
+            750: string;
+            700: string;
+            650: string;
+            600: string;
+            550: string;
+            500: string;
+            450: string;
+            400: string;
+            300: string;
+            200: string;
+            100: string;
+        };
+    };
+    namespace letterSpacing {
+        const tightest: string;
+        const tighter: string;
+        const tight: string;
+        const normal: string;
+        const wide: string;
+        const wider: string;
+        const widest: string;
+        const ultrawide: string;
+    }
+    namespace extend {
+        function borderColor(theme: any): {
+            DEFAULT: any;
+        };
+        const inset: {
+            4: string;
+            "-10": string;
+        };
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,7 +3261,7 @@
   dependencies:
     "@types/geojson" "*"
 
-"@types/markdown-to-jsx@6.11.3":
+"@types/markdown-to-jsx@^6.11.2":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
   integrity sha512-30nFYpceM/ZEvhGiqWjm5quLUxNeld0HCzJEXMZZDpq53FPkS85mTwkWtCXzCqq8s5JYLgM5W392a02xn8Bdaw==
@@ -12003,6 +12003,11 @@ prettier-linter-helpers@^1.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+
+prettier@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
This pulls the code from the alpha branch currently published as `7.2.3-alpha.1` to the main branch. This will make the required changes for bloom to be a non-alpha version.

These changes do the following:
- Bring the types back to dependencies instead of devDependencies.
  - This is how it previously was while in bloom core
  - Functionally it works without this change, everything starts up. However, when running tests it fails since bloom is unaware of these types when they are just dev dependencies. This exposes it to the consumers.
- Make `alpha` branch trigger npm builds.
  - This will allow us to have a place to test changes in a way that doesn't require triggering a full production build
  - Any change pushed to `alpha` branch will trigger an npm deploy with `-alpha.#` format
- Tailwind configuration is not getting recognized in a few tests in bloom. Adding tailwind.config.d.ts solves this problem.