### PR TITLE
test: run a11y suite in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,6 @@ workflows:
       - jest-ui-components:
           requires:
             - setup
+      - jest-ui-components-a11y:
+          requires:
+            - setup

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,16 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   testRegex: ["/*.test.tsx$", "/*.test.ts$"],
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
   transform: {
     "^.+\\.[t|j]sx?$": "ts-jest",
   },
   testEnvironment: "jsdom",
   moduleNameMapper: {
     "\\.(scss|css|less)$": "identity-obj-proxy",
+    "\\.mdx$": "<rootDir>/.jest/mock.js",
   },
   transformIgnorePatterns: ["node_modules", "node_modules/?!(nanoid)/"],
   setupFilesAfterEnv: ["<rootDir>/.jest/setup-tests.js"],
-};
+}

--- a/src/blocks/Card.stories.tsx
+++ b/src/blocks/Card.stories.tsx
@@ -46,7 +46,7 @@ export const MixedContent = () => (
     <Card>
       <div>
         <figure>
-          <img src="/images/listing.jpg" />
+          <img src="/images/listing.jpg" alt={"Image Alt"} />
         </figure>
 
         <Card.Header

--- a/src/blocks/ImageCard.stories.tsx
+++ b/src/blocks/ImageCard.stories.tsx
@@ -25,8 +25,7 @@ export const twoImages = () => (
     images={[
       { url: "/images/listing.jpg" },
       {
-        url:
-          "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
+        url: "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
       },
     ]}
   />
@@ -37,12 +36,10 @@ export const threeImages = () => (
     images={[
       { url: "/images/listing.jpg" },
       {
-        url:
-          "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
+        url: "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
       },
       {
-        url:
-          "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/house_goo3cp.jpg",
+        url: "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/house_goo3cp.jpg",
       },
     ]}
   />
@@ -53,8 +50,7 @@ export const fourImages = () => (
     images={[
       { url: "/images/listing.jpg" },
       {
-        url:
-          "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
+        url: "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/oakhouse_cgdqmx.jpg",
         mobileUrl:
           "https://res.cloudinary.com/exygy/image/upload/w_767,c_limit,q_55/dev/oakhouse_cgdqmx.jpg",
         thumbnailUrl:
@@ -62,12 +58,10 @@ export const fourImages = () => (
         description: "The second photo in the list",
       },
       {
-        url:
-          "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/house_goo3cp.jpg",
+        url: "https://res.cloudinary.com/exygy/image/upload/w_1302,c_limit,q_65/dev/house_goo3cp.jpg",
       },
       {
-        url:
-          "https://regional-dahlia-staging.s3-us-west-1.amazonaws.com/listings/triton/thetriton.png",
+        url: "https://regional-dahlia-staging.s3-us-west-1.amazonaws.com/listings/triton/thetriton.png",
       },
     ]}
     modalCloseLabel="Back to listing"
@@ -81,15 +75,11 @@ export const withLink = () => <ImageCard href="/listings" imageUrl="/images/list
 export const withNoImage = () => <ImageCard />
 
 export const withOneStatusAndSmaller = () => (
-  <header className="image-card--leader">
-    <ImageCard
-      href="/listings"
-      imageUrl="/images/listing.jpg"
-      statuses={[
-        { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
-      ]}
-    />
-  </header>
+  <ImageCard
+    href="/listings"
+    imageUrl="/images/listing.jpg"
+    statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
+  />
 )
 
 export const withDescriptionAsAlt = () => (

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -161,8 +161,9 @@ const ImageCard = (props: ImageCardProps) => {
               )}
               <button
                 aria-label={
-                  props.moreImagesDescription &&
-                  `${props.images.length - 2} ${props.moreImagesDescription}`
+                  props.moreImagesDescription
+                    ? `${props.images.length - 2} ${props.moreImagesDescription}`
+                    : "More Images"
                 }
                 data-test-id="open-modal-button"
                 onClick={() => {

--- a/src/forms/MultiSelectField.tsx
+++ b/src/forms/MultiSelectField.tsx
@@ -53,7 +53,6 @@ const MultiSelectField = (props: MultiSelectFieldProps) => {
           delay: 300, // debounce for 300ms
           inputClassName: "input",
           multiple: true,
-          placeholder: props.placeholder,
           deleteOnBackspace: true,
           showAllControl: true,
           cssNameSpace: "multi-select-field",
@@ -83,7 +82,12 @@ const MultiSelectField = (props: MultiSelectFieldProps) => {
       {props.label && label}
       <div className="control" data-test-id={props.dataTestId}>
         <Icon symbol="search" size="medium" />
-        <input id={props.id} ref={autocompleteRef} className="input" />
+        <input
+          id={props.id}
+          ref={autocompleteRef}
+          className="input"
+          placeholder={props.placeholder}
+        />
       </div>
     </div>
   )

--- a/src/headers/HeadingGroup.tsx
+++ b/src/headers/HeadingGroup.tsx
@@ -5,7 +5,7 @@ import "./HeadingGroup.scss"
 export interface HeadingGroupProps {
   /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
   heading: React.ReactNode
-  /** A string or element to display in an `p` tag (using `aria-roledescription="subtitle"`) */
+  /** A string or element to display in an `p` tag (using `role="doc-subtitle"`) */
   subheading: React.ReactNode
   /**
    * The heading level (1 through 6)
@@ -23,7 +23,7 @@ const HeadingGroup = (props: HeadingGroupProps) => {
   return (
     <hgroup className={classNames.join(" ")} role="group">
       <Heading priority={props.headingPriority ?? 2}>{props.heading}</Heading>
-      <p aria-roledescription="subtitle">{props.subheading}</p>
+      <p role="doc-subtitle">{props.subheading}</p>
     </hgroup>
   )
 }

--- a/src/page_components/listing/ListingCard.stories.tsx
+++ b/src/page_components/listing/ListingCard.stories.tsx
@@ -130,7 +130,6 @@ export const WithPillHeader = () => {
         },
         contentSubheader: { content: "Optional content subheader" },
         tableHeader: { content: "Optional table header", isPillType: true },
-        tableSubheader: { content: "Optional table subheader" },
       }}
     />
   )

--- a/src/tables/AgTable.stories.tsx
+++ b/src/tables/AgTable.stories.tsx
@@ -74,7 +74,7 @@ export const Default = () => {
   )
 }
 
-// The external library we are using is throwing an a11y error:
+// The external library we are using here (ag-grid-react) is throwing an a11y error:
 Default.parameters = {
   a11y: {
     config: {

--- a/src/tables/AgTable.stories.tsx
+++ b/src/tables/AgTable.stories.tsx
@@ -73,3 +73,17 @@ export const Default = () => {
     />
   )
 }
+
+// The external library we are using is throwing an a11y error:
+Default.parameters = {
+  a11y: {
+    config: {
+      rules: [
+        {
+          id: "aria-required-children",
+          enabled: false,
+        },
+      ],
+    },
+  },
+}

--- a/src/tables/AgTable.tsx
+++ b/src/tables/AgTable.tsx
@@ -233,7 +233,7 @@ const AgTable = ({
         </div>
         {headerContent}
       </div>
-      <div className="applications-table">
+      <div className="applications-table" aria-busy={data.loading}>
         <LoadingOverlay isLoading={data.loading}>
           <div>
             <AgGridReact

--- a/src/tables/StandardTable.tsx
+++ b/src/tables/StandardTable.tsx
@@ -182,7 +182,12 @@ export const StandardTable = (props: StandardTableProps) => {
           headerLabel={props.strings?.sortString ?? t("t.sort")}
           className={`table__draggable-cell pl-7`}
         >
-          <Icon symbol={faGripLines} size={"medium"} fill={IconFillColors.primary} />
+          <Icon
+            symbol={faGripLines}
+            size={"medium"}
+            fill={IconFillColors.primary}
+            aria-label={"Drag"}
+          />
         </Cell>
       )
     }

--- a/src/tables/StandardTable.tsx
+++ b/src/tables/StandardTable.tsx
@@ -22,7 +22,11 @@ export const Row = (props: { id?: string; className?: string; children: React.Re
 )
 
 export const HeaderCell = (props: { children: React.ReactNode; className?: string }) => (
-  <th className={props.className}>{props.children}</th>
+  <th className={props.className}>
+    <span className={!props.children ? "sr-only" : ""}>
+      {!props.children ? "Actions" : props.children}
+    </span>
+  </th>
 )
 
 export const Cell = (props: {


### PR DESCRIPTION
In porting over, we missed running the accessibility suite in CircleCi.

To test this PR, ensure the tests run and pass. In getting the suite to work, I realized some suites were silently failing due to a config issue, and once they were running some tests were failing, so it involves a few a11y fixes as well. One of the errors I had to explicitly ignore due to it being a third party issue with ag-table.