### PR TITLE
chore: Update yarn start build local Storybook on a consistent port

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build-storybook": "build-storybook -c .storybook -s ./public",
-    "start": "start-storybook -s ./public",
+    "start": "start-storybook -s ./public -p 40791",
     "build": "tsc",
     "test": "jest -w 1",
     "test:coverage": "jest -w 1 --coverage --watchAll=false",


### PR DESCRIPTION
# Pull Request Template

#issue n/a

## Description

By default, `start-storybook` and `yarn start` by extension chooses a random port to run on. However, for folks developing on remote machines, that breaks port forwarding since we have to specify specific ports to forward.

I changed the default functionality of `yarn start` to choose port 40791 (nothing specific about this port except that it was the port chosen by my first run of yarn start) -- I figure that this is a detail that most people not SSHing into remote machines will even notice, but if there is an issue here I'm happy to alternatively implement it such that so that you can pass in a argument of a port or even add a new command like `yarn start-consistent-port`.

## How Can This Be Tested/Reviewed?

Checkout onto `main`, then `yarn start`. Observe that the local Storybook is brought up on a random port.
Checkout onto this branch, then `yarn start`. Observe that the local Storybook is brought up on port 40791.

(I did this ^ to test my changes)

## Checklist:

- [x] My code follows the style guidelines of this project
- [] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
