### PR TITLE
fix: add variable width to description titles

### DIFF
--- a/src/page_components/listing/listing_sidebar/Contact.tsx
+++ b/src/page_components/listing/listing_sidebar/Contact.tsx
@@ -21,6 +21,8 @@ export interface ContactProps {
   contactPhoneNumberNote?: string
   /** The contact's title */
   contactTitle?: string
+  /** Classnames to style the contact's title */
+  contactTitleClassname?: string
   /** The text for the section's header */
   sectionTitle: string
   strings: { email?: string; getDirections: string; website?: string }
@@ -36,6 +38,7 @@ const Contact = ({
   contactPhoneNumber,
   contactPhoneNumberNote,
   contactTitle,
+  contactTitleClassname,
   sectionTitle,
   strings,
 }: ContactProps) => {
@@ -46,6 +49,8 @@ const Contact = ({
     contactCompany?.website && !contactCompany?.website.startsWith("http")
       ? `http://${contactCompany?.website}`
       : contactCompany?.website
+  const contactTitleClasses = ["text-gray-700"]
+  if (contactTitleClassname) contactTitleClasses.push(contactTitleClassname)
 
   return (
     <section className="aside-block">
@@ -54,7 +59,7 @@ const Contact = ({
       </Heading>
 
       {contactName && <p className="text-xl">{contactName}</p>}
-      {contactTitle && <p className="text-gray-700">{contactTitle}</p>}
+      {contactTitle && <p className={contactTitleClasses.join(" ")}>{contactTitle}</p>}
       {contactCompany?.name && <p className="text-gray-700">{contactCompany.name}</p>}
 
       {contactPhoneNumber && (

--- a/src/text/Description.scss
+++ b/src/text/Description.scss
@@ -17,32 +17,35 @@
 // Data lists
 .column-definition-list {
   @include clearfix;
-
+  @apply grid;
+  grid-template-columns: 1fr 1fr;
+  @apply gap-x-4;
+  grid-row-gap: 0.15rem;
+  
   .description__title {
     @apply text-xl;
     @apply text-gray-800;
     @apply mb-3;
     clear: left;
+    height: max-content;
+    @apply w-full;
 
     @screen md {
       @apply pl-4;
       @apply border-l-2;
       @apply border-gray-450;
       @apply float-left;
-      @apply w-1/3;
-      @apply pr-3;
-      margin-top: 0.15rem;
     }
   }
 
   .description__body {
     @apply text-sm;
     @apply mb-5;
+    @apply w-full;
 
     @screen md {
       @apply mb-0;
       @apply float-left;
-      @apply w-2/3;
     }
 
     &:last-of-type {

--- a/src/text/Description.scss
+++ b/src/text/Description.scss
@@ -17,10 +17,13 @@
 // Data lists
 .column-definition-list {
   @include clearfix;
-  @apply grid;
-  grid-template-columns: 1fr 1fr;
-  @apply gap-x-4;
-  grid-row-gap: 0.15rem;
+
+  @screen md {
+    @apply grid;
+    grid-template-columns: 1fr 1fr;
+    @apply gap-x-4;
+    grid-row-gap: 0.15rem;
+  }
   
   .description__title {
     @apply text-xl;
@@ -46,10 +49,13 @@
     @screen md {
       @apply mb-0;
       @apply float-left;
+      &:last-of-type {
+        @apply col-span-2;
+      }
     }
 
     &:last-of-type {
-      @apply w-full;
+      @apply w-full
     }
   }
 }

--- a/src/text/Description.tsx
+++ b/src/text/Description.tsx
@@ -16,16 +16,16 @@ export const Description = (props: DescriptionProps) => {
 
   return (
     <>
-      <dd className="description__title">{props.term}</dd>
+      <dt className="description__title">{props.term}</dt>
       {props.markdown ? (
-        <dt className={dtClasses.join(" ")}>
+        <dd className={dtClasses.join(" ")}>
           <Markdown
             options={{ disableParsingRawHTML: true, ...props.markdownProps }}
             children={props.description}
           />
-        </dt>
+        </dd>
       ) : (
-        <dt className={dtClasses.join(" ")}>{props.description}</dt>
+        <dd className={dtClasses.join(" ")}>{props.description}</dd>
       )}
     </>
   )


### PR DESCRIPTION
## Description

There are two issues within DAHLIA related to translations. The first is that, within the Contact component, we need to have the ability to pass a classname to the Contact Title element. This allows us to specifically target that element for machine translation.

The second issue related to the Description component. Currently, the widths of the term and definition column are hardcoded as 33% and 66%, respectively. However, there are instances (specifically at small screen widths) when a single word exceeds the width of the term column. For example, in English Appliances fits into the term column, but when translated to Spanish, this term becomes "Electrodomésticos" which would run over into the definition column. A fix for this is to use grid to allow the columns width to be flexible but also uniform across the different rows.

A third issue, unrelated to translations but important for DOM readability, is that in the Description component, the `dt` and `dd` tags should be flipped where the term element precedes the description element.

## How Can This Be Tested/Reviewed?

For testing the Contact component:
- Review the Contact component in Storybook and ensure that there are no visual differences. This change is to only allow for the addition of extra classnames to the title element.

For testing the Description component element switch (dt/dd):
- Review the Description component and ensure that there are no changes to the functionality / style-ability of the component. The only change to this component was switching element tags.

For testing the Description component styling changes:
- Check it out in DAHLIA and ensure that the words do not overrun each other even at smaller widths.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
