### PR TITLE
fix: Remove Z-Index Requirement for Listing Tags

### DIFF
--- a/src/blocks/ImageCard.scss
+++ b/src/blocks/ImageCard.scss
@@ -118,7 +118,7 @@
   align-items: center;
   justify-content: var(--tags-justify);
   position: absolute;
-  z-index: 10;
+  top: 0;
   width: 100%;
   margin-block-start: var(--bloom-s1);
   padding-inline: var(--bloom-s4);

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -81,10 +81,7 @@ const ImageCard = (props: ImageCardProps) => {
       )
     })
     return (
-      <aside
-        className="image-card__status"
-        aria-label={`${props.description ? props.description : ""} Statuses`}
-      >
+      <aside className="image-card__status" aria-label={`${props.description || ""} Statuses`}>
         {statuses}
       </aside>
     )

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -81,7 +81,10 @@ const ImageCard = (props: ImageCardProps) => {
       )
     })
     return (
-      <aside className="image-card__status" aria-label={`${props.description} Statuses`}>
+      <aside
+        className="image-card__status"
+        aria-label={`${props.description ? props.description : ""} Statuses`}
+      >
         {statuses}
       </aside>
     )
@@ -104,24 +107,6 @@ const ImageCard = (props: ImageCardProps) => {
   const image = (
     <>
       <div className="image-card">
-        <div className="image-card-tag__wrapper">
-          {props.tags?.map((tag, index) => {
-            return (
-              <React.Fragment key={index}>
-                <Tag styleType={tag.styleType || AppearanceStyleType.warning}>
-                  {tag.iconType && (
-                    <Icon
-                      size={"medium"}
-                      symbol={tag.iconType}
-                      fill={tag.iconColor ?? IconFillColors.primary}
-                    />
-                  )}
-                  {tag.text}
-                </Tag>
-              </React.Fragment>
-            )
-          })}
-        </div>
         <figure className={innerClasses.join(" ")}>
           {props.imageUrl ? (
             <img
@@ -174,6 +159,24 @@ const ImageCard = (props: ImageCardProps) => {
           )}
         </figure>
         {getStatuses()}
+        <div className="image-card-tag__wrapper">
+          {props.tags?.map((tag, index) => {
+            return (
+              <React.Fragment key={index}>
+                <Tag styleType={tag.styleType || AppearanceStyleType.warning}>
+                  {tag.iconType && (
+                    <Icon
+                      size={"medium"}
+                      symbol={tag.iconType}
+                      fill={tag.iconColor ?? IconFillColors.primary}
+                    />
+                  )}
+                  {tag.text}
+                </Tag>
+              </React.Fragment>
+            )
+          })}
+        </div>
       </div>
       {props.images && props.images.length > 1 && (
         <Modal


### PR DESCRIPTION
# Pull Request Template

#29 

## Description

DAHLIA identified an issue where the listing tag renders on top of the slide out mobile menu. This occurred whenever the listing tag was present.

## How Can This Be Tested/Reviewed?

**In storybook**
Check to ensure that the listing tags are rendering correctly.
**In DAHLIA (or Bloom)**
1. Check to ensure that the listing tags render correctly on the listing details page and the rental listings page.
2. Using the inspector or an emulator, change the viewport to be a mobile version. 
3. Go to the listings page and find a listing with listing tags on them. 
4. Open the slide out menu by clicking the hamburger icon in the top right
5. The Listing tag should be underneath the menu
6. Try this on the listing details page

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
