### PR TITLE
refactor: release all types of commit tags

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
At the moment, we're not releasing this package on every commit even if the commit message is in the conventional commit format.

For example, you can see that the [SiteHeader refactor PR](https://github.com/bloom-housing/ui-components/pull/21) was committed to main with this message (`refactor: update SiteHeader to support CSS overrides`) but was not actually released. If you check out [the GitHub action](https://github.com/bloom-housing/ui-components/actions/runs/4224903177/jobs/7336462191) for the release of this PR you see this in the output: `[@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release`

There is a [default set of rules for release](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) which from the set of options for conventional commits only includes feat, fix, and perf.

Updating the config for this step to `conventionalcommits` should release on every commit w all of the available tags. Merging this PR with `refactor` as the tag will be a good test!