### PR TITLE
fix: Add optional background to page header

### DIFF
--- a/src/headers/PageHeader.stories.tsx
+++ b/src/headers/PageHeader.stories.tsx
@@ -28,6 +28,10 @@ export const withContent = () => (
   </PageHeader>
 )
 
+export const withBackgroundImage = () => (
+  <PageHeader title="Hello World" inverse subtitle="Here is a page header with a background image" backgroundImage="/images/banner.png" className="bg-cover bg-center"/>
+)
+
 export const styleOverrides = () => {
   const cssVarsOverride = `
     .page-header-overrides .page-header {

--- a/src/headers/PageHeader.tsx
+++ b/src/headers/PageHeader.tsx
@@ -9,15 +9,20 @@ export interface PageHeaderProps {
   children?: React.ReactNode
   tabNav?: React.ReactNode
   breadcrumbs?: React.ReactNode
+  backgroundImage?: string
 }
 
 const PageHeader = (props: PageHeaderProps) => {
   const classNames = ["page-header"]
+  let styles
   if (props.inverse) classNames.push("is-inverse")
   if (props.className) classNames.push(...props.className.split(" "))
+  if (props.backgroundImage) {
+    styles = { backgroundImage: `url(${props.backgroundImage})` }
+  }
 
   return (
-    <header className={classNames.join(" ")}>
+    <header className={classNames.join(" ")} style={styles}>
       <hgroup className="page-header__group">
         {props?.breadcrumbs && (
           <nav className="page-header__breadcrumbs" aria-label={"Page Header"}>


### PR DESCRIPTION
# Pull Request Template

#39 

## Description

For the Get Assistance pages, we want to have an image in the background of the header.

## How Can This Be Tested/Reviewed?

The best way to test this is on Storybook. There is now a variant where a background image is provided.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
