### PR TITLE
fix: align ImageCard with detroit updates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ export * from "./src/blocks/StatusBar"
 export * from "./src/blocks/ViewItem"
 export * from "./src/blocks/StandardCard"
 export * from "./src/blocks/MediaCard"
+export * from "./src/blocks/Tooltip"
 
 /* Contexts */
 export * from "./src/config"

--- a/src/blocks/ImageCard.scss
+++ b/src/blocks/ImageCard.scss
@@ -107,7 +107,7 @@
       color: var(--bloom-color-white);
       background: rgba(0, 0, 0, 0.6);
       @media (max-width: $screen-sm) {
-        font-size: var(--bloom-font-size-sm);
+        font-size: var(--bloom-font-size-xs);
         line-height: var(--bloom-line-height-none);
       }
     }

--- a/src/blocks/ImageCard.scss
+++ b/src/blocks/ImageCard.scss
@@ -1,4 +1,5 @@
 @import "../global/mixins.scss";
+@import "../global/accessibility.scss";
 
 .image-card {
   /* Component Variables */
@@ -17,6 +18,11 @@
   position: relative;
   background-color: var(--default-background-color);
   border-radius: var(--border-radius);
+
+  button:focus {
+    outline: none;
+    box-shadow: 0 0 3px 4px var(--bloom-color-accent-cool);
+  }
 
   img {
     border-radius: var(--border-radius);
@@ -98,9 +104,10 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-
+      color: var(--bloom-color-white);
+      background: rgba(0, 0, 0, 0.6);
       @media (max-width: $screen-sm) {
-        font-size: var(--bloom-font-size-xs);
+        font-size: var(--bloom-font-size-sm);
         line-height: var(--bloom-line-height-none);
       }
     }
@@ -119,6 +126,7 @@
   justify-content: var(--tags-justify);
   position: absolute;
   top: 0;
+  z-index: 10;
   width: 100%;
   margin-block-start: var(--bloom-s1);
   padding-inline: var(--bloom-s4);
@@ -157,4 +165,22 @@
   --footer-justify: center;
   --modal-border: none;
   --modal-shadow: none;
+  @media (min-width: $screen-md) {
+    --scroll-max-height: calc(80vh - 200px);
+    max-width: var(--bloom-width-5xl);
+  }
+  section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  button {
+    outline: none;
+  }
+  svg {
+    @extend .sr-only;
+  }
+  footer button:focus {
+    box-shadow: 0 0 3px 4px var(--bloom-color-accent-cool);
+  }
 }

--- a/src/blocks/ImageCard.stories.tsx
+++ b/src/blocks/ImageCard.stories.tsx
@@ -75,11 +75,15 @@ export const withLink = () => <ImageCard href="/listings" imageUrl="/images/list
 export const withNoImage = () => <ImageCard />
 
 export const withOneStatusAndSmaller = () => (
-  <ImageCard
-    href="/listings"
-    imageUrl="/images/listing.jpg"
-    statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
-  />
+  <header className="image-card--leader">
+    <ImageCard
+      href="/listings"
+      imageUrl="/images/listing.jpg"
+      statuses={[
+        { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
+      ]}
+    />
+  </header>
 )
 
 export const withDescriptionAsAlt = () => (

--- a/src/blocks/ImageCard.stories.tsx
+++ b/src/blocks/ImageCard.stories.tsx
@@ -75,15 +75,11 @@ export const withLink = () => <ImageCard href="/listings" imageUrl="/images/list
 export const withNoImage = () => <ImageCard />
 
 export const withOneStatusAndSmaller = () => (
-  <header className="image-card--leader">
-    <ImageCard
-      href="/listings"
-      imageUrl="/images/listing.jpg"
-      statuses={[
-        { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
-      ]}
-    />
-  </header>
+  <ImageCard
+    href="/listings"
+    imageUrl="/images/listing.jpg"
+    statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
+  />
 )
 
 export const withDescriptionAsAlt = () => (

--- a/src/blocks/ImageCard.stories.tsx
+++ b/src/blocks/ImageCard.stories.tsx
@@ -3,7 +3,7 @@ import { BADGES } from "../../.storybook/constants"
 import { ImageCard } from "./ImageCard"
 import { t } from "../helpers/translator"
 import { ApplicationStatusType } from "../global/ApplicationStatusType"
-import { IconFillColors } from "../icons/Icon"
+import { IconFillColors, UniversalIconType } from "../icons/Icon"
 import ImageCardDocumentation from "./ImageCard.docs.mdx"
 
 export default {
@@ -105,6 +105,32 @@ export const withMultipleTags = () => (
     tags={[{ text: "Label" }, { text: "Label2" }]}
     statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
   />
+)
+
+export const withTooltip = () => (
+  <div style={{ margin: "5rem" }}>
+    <ImageCard
+      href="/listings"
+      imageUrl="/images/listing.jpg"
+      tags={[
+        {
+          text: "Label",
+        },
+        {
+          text: "Label2",
+          iconType: "globe" as UniversalIconType,
+          iconColor: IconFillColors.white,
+          tooltip: {
+            id: "tooltip",
+            text: "Here is some helpful tooltip content. Here is even more helpful tooltip content.",
+          },
+        },
+      ]}
+      statuses={[
+        { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
+      ]}
+    />
+  </div>
 )
 
 export const withLongTagsAndIcons = () => (

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -159,7 +159,12 @@ const ImageCard = (props: ImageCardProps) => {
         <div className="image-card-tag__wrapper">
           {props.tags?.map((tag, index) => {
             const tagContent = (
-              <Tag tabIndex={0} styleType={tag.styleType || AppearanceStyleType.warning}>
+              <Tag
+                styleType={tag.styleType || AppearanceStyleType.warning}
+                ariaLabel={
+                  tag.tooltip ? `${tag.text || ""} - ${tag.tooltip?.text || ""}` : undefined
+                }
+              >
                 {tag.iconType && (
                   <Icon
                     size={"medium"}

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -3,6 +3,7 @@ import { LocalizedLink } from "../actions/LocalizedLink"
 import { ApplicationStatus } from "../notifications/ApplicationStatus"
 import "./ImageCard.scss"
 import { Tag } from "../text/Tag"
+import { TooltipProps, Tooltip } from "./Tooltip"
 import { ApplicationStatusType } from "../global/ApplicationStatusType"
 import { AppearanceSizeType, AppearanceStyleType } from "../global/AppearanceTypes"
 import { Icon, IconFillColors, UniversalIconType } from "../icons/Icon"
@@ -18,11 +19,14 @@ export interface StatusBarType {
   iconType?: UniversalIconType
 }
 
+export type ImageTagTooltip = Pick<TooltipProps, "id" | "text">
+
 export interface ImageTag {
   text?: string
   iconType?: UniversalIconType
   iconColor?: string
   styleType?: AppearanceStyleType
+  tooltip?: ImageTagTooltip
 }
 
 export interface ImageItem {
@@ -154,20 +158,29 @@ const ImageCard = (props: ImageCardProps) => {
         {getStatuses()}
         <div className="image-card-tag__wrapper">
           {props.tags?.map((tag, index) => {
-            return (
-              <React.Fragment key={index}>
-                <Tag styleType={tag.styleType || AppearanceStyleType.warning}>
-                  {tag.iconType && (
-                    <Icon
-                      size={"medium"}
-                      symbol={tag.iconType}
-                      fill={tag.iconColor ?? IconFillColors.primary}
-                    />
-                  )}
-                  {tag.text}
-                </Tag>
-              </React.Fragment>
+            const tagContent = (
+              <Tag tabIndex={0} styleType={tag.styleType || AppearanceStyleType.warning}>
+                {tag.iconType && (
+                  <Icon
+                    size={"medium"}
+                    symbol={tag.iconType}
+                    fill={tag.iconColor ?? IconFillColors.primary}
+                    className={"mr-2"}
+                  />
+                )}
+                {tag.text}
+              </Tag>
             )
+
+            if (tag.tooltip) {
+              return (
+                <Tooltip key={index} className="mt-3" {...tag.tooltip}>
+                  {tagContent}
+                </Tooltip>
+              )
+            }
+
+            return <React.Fragment key={index}>{tagContent}</React.Fragment>
           })}
         </div>
       </div>

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -80,11 +80,7 @@ const ImageCard = (props: ImageCardProps) => {
         />
       )
     })
-    return (
-      <aside className="image-card__status" aria-label={`${props.description || ""} Statuses`}>
-        {statuses}
-      </aside>
-    )
+    return <aside aria-label={`${props.description || ""} Statuses`}>{statuses}</aside>
   }
 
   const innerClasses = ["image-card__inner"]
@@ -191,24 +187,21 @@ const ImageCard = (props: ImageCardProps) => {
             </Button>,
           ]}
         >
-          {props.images &&
-            props.images.map((image, index) => (
-              <p key={index} className="mb-7">
-                <picture>
-                  {image.mobileUrl && (
-                    <source media="(max-width: 767px)" srcSet={image.mobileUrl} />
-                  )}
-                  <img
-                    src={image.url}
-                    alt={
-                      image.description
-                        ? image.description
-                        : `${props.description || ""} - photo ${index + 1}`
-                    }
-                  />
-                </picture>
-              </p>
-            ))}
+          {props.images?.map((image, index) => (
+            <p key={index} className="mb-7">
+              <picture>
+                {image.mobileUrl && <source media="(max-width: 767px)" srcSet={image.mobileUrl} />}
+                <img
+                  src={image.url}
+                  alt={
+                    image.description
+                      ? image.description
+                      : `${props.description || ""} - photo ${index + 1}`
+                  }
+                />
+              </picture>
+            </p>
+          ))}
         </Modal>
       )}
     </>

--- a/src/blocks/ImageCard.tsx
+++ b/src/blocks/ImageCard.tsx
@@ -193,7 +193,7 @@ const ImageCard = (props: ImageCardProps) => {
         <Modal
           open={showModal}
           title={props.modalAriaTitle || "Images"}
-          scrollable={true}
+          scrollableModal={true}
           onClose={() => setShowModal(!showModal)}
           className="image-card__overlay"
           modalClassNames="image-card__gallery-modal"

--- a/src/blocks/Tooltip.scss
+++ b/src/blocks/Tooltip.scss
@@ -1,0 +1,43 @@
+.tooltip {
+  @apply relative;
+  display: inline-block;
+  width: fit-content;
+}
+
+.tooltip__element {
+  @apply w-full;
+  @apply fixed;
+  @apply bg-primary-dark;
+  @apply text-white;
+  @apply rounded;
+  @apply p-2;
+  @apply text-sm;
+  @apply font-bold;
+  @apply text-center;
+  @apply normal-case;
+  @apply opacity-0;
+  @apply invisible;
+  transform: translate(-50%, calc(-100% - 10px * 2));
+
+  max-width: 280px;
+  transition: opacity 0.2s;
+
+  &--visible {
+    @apply opacity-100;
+    @apply visible;
+  }
+
+  &::before {
+    content: "";
+    @apply absolute;
+    @apply bottom-0;
+    @apply w-0;
+    @apply h-0;
+    @apply border-solid;
+    left: 50%;
+    bottom: -8px;
+    transform: translateX(-50%);
+    border-width: 10px 7px 0 7px;
+    border-color: theme("colors.primary-dark") transparent transparent transparent;
+  }
+}

--- a/src/blocks/Tooltip.tsx
+++ b/src/blocks/Tooltip.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useRef, useEffect } from "react"
+import useKeyPress from "../helpers/useKeyPress"
+import "./Tooltip.scss"
+
+export interface TooltipProps {
+  className?: string
+  id: string
+  text: string
+}
+
+export interface TooltipPosition {
+  top: number
+  left: number
+}
+
+const Tooltip = ({ className, id, text, children }: React.PropsWithChildren<TooltipProps>) => {
+  const [position, setPosition] = useState<TooltipPosition | null>(null)
+  const childrenWrapperRef = useRef<HTMLDivElement>(null)
+
+  const show = () => {
+    const { x, y, width, height } = childrenWrapperRef.current?.getBoundingClientRect() || {}
+
+    if (x && y && width && height) {
+      setPosition({ top: y, left: x + width / 2 })
+    }
+  }
+
+  const hide = () => setPosition(null)
+
+  useKeyPress("Escape", () => hide())
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => hide())
+
+    return () => {
+      window.removeEventListener("scroll", () => hide())
+    }
+  }, [])
+
+  return (
+    <div
+      className={`tooltip ${className || ""}`}
+      onFocus={show}
+      onMouseEnter={show}
+      onBlur={hide}
+      onMouseLeave={hide}
+    >
+      <div
+        className={`tooltip__element ${position ? "tooltip__element--visible" : ""}`}
+        style={position || {}}
+        role="tooltip"
+        id={id}
+        data-test-id="tooltip-element"
+      >
+        {text}
+      </div>
+
+      <div className="tooltip__children" data-test-id="tooltip-children" ref={childrenWrapperRef}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export { Tooltip as default, Tooltip }

--- a/src/text/Tag.tsx
+++ b/src/text/Tag.tsx
@@ -8,7 +8,7 @@ export interface TagProps extends AppearanceProps {
   capitalized?: boolean
   children: React.ReactNode
   fillContainer?: boolean
-  tabIndex?: number
+  ariaLabel?: string
 }
 
 export const Tag = (props: TagProps) => {
@@ -20,7 +20,7 @@ export const Tag = (props: TagProps) => {
   if (props.className) tagClasses.push(props.className)
 
   return (
-    <span className={tagClasses.join(" ")} tabIndex={props.tabIndex}>
+    <span className={tagClasses.join(" ")} aria-label={props.ariaLabel || undefined}>
       {props.children}
     </span>
   )

--- a/src/text/Tag.tsx
+++ b/src/text/Tag.tsx
@@ -8,6 +8,7 @@ export interface TagProps extends AppearanceProps {
   capitalized?: boolean
   children: React.ReactNode
   fillContainer?: boolean
+  tabIndex?: number
 }
 
 export const Tag = (props: TagProps) => {
@@ -18,5 +19,9 @@ export const Tag = (props: TagProps) => {
   if (props.capitalized) tagClasses.push("is-capitalized")
   if (props.className) tagClasses.push(props.className)
 
-  return <span className={tagClasses.join(" ")}>{props.children}</span>
+  return (
+    <span className={tagClasses.join(" ")} tabIndex={props.tabIndex}>
+      {props.children}
+    </span>
+  )
 }


### PR DESCRIPTION
# Pull Request Template

#55

## Description

Aligns the ImageCard component with the changes in Detroit.

## How Can This Be Tested/Reviewed?

Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/blocks-image-card--image) to the stories on [this PR](https://deploy-preview-42--storybook-bloom-dev.netlify.app/?path=/story/blocks-image-card--image). This PR includes pulling over the Tooltip component.

While testing in Detroit I noticed that while we used to show a tooltip on the `Verified` tags on the ImageCard we no longer were passing that in. Jesse considers that a regression so once we uptake in Detroit we will re-pass in that tooltip.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
