### PR TITLE
fix: align ViewItem with detroit updates

### DIFF
--- a/src/blocks/ViewItem.scss
+++ b/src/blocks/ViewItem.scss
@@ -4,64 +4,68 @@
   --label-font-size: var(--bloom-font-size-sm);
   --helper-font-size: var(--bloom-font-size-sm);
   --label-error-font-size: var(--bloom-font-size-sm);
-  @apply relative;
-  @apply text-base;
-  @apply mb-4;
+  --label-text-color: var(--bloom-color-gray-800);
+  --helper-text-color: var(--bloom-color-gray-750);
+  --font-size: var(--bloom-font-size-base);
+  --bottom-margin: var(--bloom-s4);
+
+  font-size: var(--font-size);
+  margin-bottom: var(--bottom-margin);
+  position: relative;
 
   &:last-of-type {
-    @apply mb-0;
+    margin-bottom: 0;
   }
 
   &.is-flagged {
-    @apply bg-warn-light;
-    @apply -my-1;
-    @apply py-1;
-    @apply -ml-8;
-    @apply pl-8;
-    box-shadow: inset 2px 0px 0px 0px $tailwind-warn;
+    background-color: var(--bloom-color-warn-light);
+    margin: calc(var(--bloom-s1) * -1) 0;
+    margin-left: calc(var(--bloom-s8) * -1);
+    padding: var(--bloom-s1) 0;
+    padding-left: var(--bloom-s8);
+    box-shadow: inset 2px 0px 0px 0px var(--bloom-color-warn);
   }
 
   .edit-link {
-    @apply absolute;
+    position: absolute;
     right: 0;
     top: 0;
   }
 }
 
 .view-item__label {
-  @apply text-gray-800;
-  @apply font-sans;
+  color: var(--label-text-color);
+  font-family: var(--bloom-font-sans);
   font-size: var(--label-font-size);
-  @apply block;
+  display: block;
 }
 
 .view-item__label-error {
-  @apply text-alert;
+  color: var(--bloom-color-alert);
   font-size: var(--label-error-font-size);
 }
 
 .view-item__value {
-  @apply font-alt-sans;
-  @apply tracking-wide;
-  @apply font-semibold;
-  @apply block;
+  font-family: var(--bloom-font-alt-sans);
+  letter-spacing: var(--bloom-letter-spacing-wide);
+  font-weight: 600;
+  display: block;
   padding-top: 10px;
 
   &.is-truncated {
     @include ellipsis;
   }
 
-  // do not change font-family for inputs
   .field .control .input,
   .error-message {
-    @apply font-sans;
-    @apply font-normal;
+    font-family: var(--bloom-font-sans);
+    font-weight: 400;
   }
 }
 
 .view-item__helper {
-  @apply text-gray-750;
-  @apply font-sans;
+  color: var(--helper-text-color);
+  font-family: var(--bloom-font-sans);
   font-size: var(--helper-font-size);
-  @apply block;
+  display: block;
 }

--- a/src/blocks/ViewItem.scss
+++ b/src/blocks/ViewItem.scss
@@ -1,6 +1,9 @@
 @import "../global/mixins.scss";
 
 .view-item {
+  --label-font-size: var(--bloom-font-size-sm);
+  --helper-font-size: var(--bloom-font-size-sm);
+  --label-error-font-size: var(--bloom-font-size-sm);
   @apply relative;
   @apply text-base;
   @apply mb-4;
@@ -28,8 +31,13 @@
 .view-item__label {
   @apply text-gray-800;
   @apply font-sans;
-  @apply text-sm;
+  font-size: var(--label-font-size);
   @apply block;
+}
+
+.view-item__label-error {
+  @apply text-alert;
+  font-size: var(--label-error-font-size);
 }
 
 .view-item__value {
@@ -54,6 +62,6 @@
 .view-item__helper {
   @apply text-gray-750;
   @apply font-sans;
-  @apply text-sm;
+  font-size: var(--helper-font-size);
   @apply block;
 }

--- a/src/blocks/ViewItem.tsx
+++ b/src/blocks/ViewItem.tsx
@@ -11,6 +11,7 @@ export interface ViewItemProps {
   truncated?: boolean
   error?: boolean
   dataTestId?: string
+  labelClassName?: string
 }
 
 const ViewItem = (props: ViewItemProps) => {
@@ -25,7 +26,11 @@ const ViewItem = (props: ViewItemProps) => {
   return (
     <div id={props.id} className={viewItemClasses.join(" ")} data-test-id={props.dataTestId}>
       {props.label && (
-        <span className={`view-item__label ${props.error ? "text-alert text-sm" : ""}`}>
+        <span
+          className={`view-item__label ${props.labelClassName || ""} ${
+            props.error ? "view-item__label-error" : ""
+          }`}
+        >
           {props.label}
         </span>
       )}

--- a/src/blocks/ViewItem.tsx
+++ b/src/blocks/ViewItem.tsx
@@ -11,7 +11,6 @@ export interface ViewItemProps {
   truncated?: boolean
   error?: boolean
   dataTestId?: string
-  labelClassName?: string
 }
 
 const ViewItem = (props: ViewItemProps) => {
@@ -26,11 +25,7 @@ const ViewItem = (props: ViewItemProps) => {
   return (
     <div id={props.id} className={viewItemClasses.join(" ")} data-test-id={props.dataTestId}>
       {props.label && (
-        <span
-          className={`view-item__label ${props.labelClassName || ""} ${
-            props.error ? "view-item__label-error" : ""
-          }`}
-        >
+        <span className={`view-item__label ${props.error ? "view-item__label-error" : ""}`}>
           {props.label}
         </span>
       )}


### PR DESCRIPTION
# Pull Request Template

#58

## Description

Allows for custom styling. There is an additional prop in Detroit for a label class name but the style overrides solve this problem.

This component is relatively soon --> seeds.

## How Can This Be Tested/Reviewed?

Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/blocks-view-item--default) to stories on [this PR](https://deploy-preview-45--storybook-bloom-dev.netlify.app/?path=/story/blocks-view-item--default).

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
