### PR TITLE
fix: align ExpandableContent with detroit updates

### DIFF
--- a/src/actions/ExpandableContent.stories.tsx
+++ b/src/actions/ExpandableContent.stories.tsx
@@ -13,3 +13,9 @@ export const standard = () => (
     {content}
   </ExpandableContent>
 )
+
+export const below = () => (
+  <ExpandableContent strings={{ readMore: "read more", readLess: "read less" }} order={"below"}>
+    {content}
+  </ExpandableContent>
+)

--- a/src/actions/ExpandableContent.stories.tsx
+++ b/src/actions/ExpandableContent.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { ExpandableContent } from "./ExpandableContent"
+import { ExpandableContent, Order } from "./ExpandableContent"
 
 export default {
   title: "Actions/Expandable Content",
@@ -15,7 +15,7 @@ export const standard = () => (
 )
 
 export const below = () => (
-  <ExpandableContent strings={{ readMore: "read more", readLess: "read less" }} order={"below"}>
+  <ExpandableContent strings={{ readMore: "read more", readLess: "read less" }} order={Order.below}>
     {content}
   </ExpandableContent>
 )

--- a/src/actions/ExpandableContent.tsx
+++ b/src/actions/ExpandableContent.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react"
 
-type Order = "above" | "below"
+export enum Order {
+  above = "above",
+  below = "below",
+}
 
 type ExpandableContentProps = {
   children: React.ReactNode
@@ -16,14 +19,14 @@ const ExpandableContent = ({
   children,
   strings,
   className,
-  order = "above",
+  order = Order.above,
 }: ExpandableContentProps) => {
   const [isExpanded, setExpanded] = useState(false)
   const rootClassNames = className ? `${className}` : undefined
 
   return (
     <div className={rootClassNames}>
-      {order === "above" && <>{isExpanded && <div>{children}</div>}</>}
+      {order === Order.above && <>{isExpanded && <div>{children}</div>}</>}
       <button
         type="button"
         className="button is-unstyled m-0 no-underline has-toggle"
@@ -34,7 +37,7 @@ const ExpandableContent = ({
       >
         {isExpanded ? strings.readLess : strings.readMore}
       </button>
-      {order === "below" && <>{isExpanded && <div>{children}</div>}</>}
+      {order === Order.below && <>{isExpanded && <div>{children}</div>}</>}
     </div>
   )
 }

--- a/src/actions/ExpandableContent.tsx
+++ b/src/actions/ExpandableContent.tsx
@@ -1,21 +1,29 @@
 import React, { useState } from "react"
 
+type Order = "above" | "below"
+
 type ExpandableContentProps = {
-  children: React.ReactChild
+  children: React.ReactNode
   strings: {
     readMore?: string
     readLess?: string
   }
   className?: string
+  order?: Order
 }
 
-const ExpandableContent = ({ children, strings, className }: ExpandableContentProps) => {
+const ExpandableContent = ({
+  children,
+  strings,
+  className,
+  order = "above",
+}: ExpandableContentProps) => {
   const [isExpanded, setExpanded] = useState(false)
   const rootClassNames = className ? `${className}` : undefined
 
   return (
     <div className={rootClassNames}>
-      {isExpanded && <div>{children}</div>}
+      {order === "above" && <>({isExpanded && <div>{children}</div>})</>}
       <button
         type="button"
         className="button is-unstyled m-0 no-underline has-toggle"
@@ -26,6 +34,7 @@ const ExpandableContent = ({ children, strings, className }: ExpandableContentPr
       >
         {isExpanded ? strings.readLess : strings.readMore}
       </button>
+      {order === "below" && <>({isExpanded && <div>{children}</div>})</>}
     </div>
   )
 }

--- a/src/actions/ExpandableContent.tsx
+++ b/src/actions/ExpandableContent.tsx
@@ -23,7 +23,7 @@ const ExpandableContent = ({
 
   return (
     <div className={rootClassNames}>
-      {order === "above" && <>({isExpanded && <div>{children}</div>})</>}
+      {order === "above" && <>{isExpanded && <div>{children}</div>}</>}
       <button
         type="button"
         className="button is-unstyled m-0 no-underline has-toggle"
@@ -34,7 +34,7 @@ const ExpandableContent = ({
       >
         {isExpanded ? strings.readLess : strings.readMore}
       </button>
-      {order === "below" && <>({isExpanded && <div>{children}</div>})</>}
+      {order === "below" && <>{isExpanded && <div>{children}</div>}</>}
     </div>
   )
 }


### PR DESCRIPTION
# Pull Request Template

#60

## Description

Allows for the content to be rendered above or below the expand button.

## How Can This Be Tested/Reviewed?

Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/actions-expandable-content--standard) to stories on [this PR](https://deploy-preview-47--storybook-bloom-dev.netlify.app/?path=/story/actions-expandable-content--standard).

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
