### PR TITLE
fix: align HeadingGroup with detroit updates

### DIFF
--- a/src/headers/HeadingGroup.tsx
+++ b/src/headers/HeadingGroup.tsx
@@ -5,7 +5,7 @@ import "./HeadingGroup.scss"
 export interface HeadingGroupProps {
   /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
   heading: React.ReactNode
-  /** A string or element to display in an `p` tag (using `aria-roledescription="subtitle"`) */
+  /** A string or element to display in an `p` */
   subheading: React.ReactNode
   /**
    * The heading level (1 through 6)
@@ -23,9 +23,7 @@ const HeadingGroup = (props: HeadingGroupProps) => {
   return (
     <hgroup className={classNames.join(" ")} role="group">
       <Heading priority={props.headingPriority ?? 2}>{props.heading}</Heading>
-      <p role={"heading"} aria-roledescription="subtitle">
-        {props.subheading}
-      </p>
+      <p>{props.subheading}</p>
     </hgroup>
   )
 }

--- a/src/headers/HeadingGroup.tsx
+++ b/src/headers/HeadingGroup.tsx
@@ -23,7 +23,9 @@ const HeadingGroup = (props: HeadingGroupProps) => {
   return (
     <hgroup className={classNames.join(" ")} role="group">
       <Heading priority={props.headingPriority ?? 2}>{props.heading}</Heading>
-      <p aria-roledescription="subtitle">{props.subheading}</p>
+      <p role={"heading"} aria-roledescription="subtitle">
+        {props.subheading}
+      </p>
     </hgroup>
   )
 }

--- a/src/headers/HeadingGroup.tsx
+++ b/src/headers/HeadingGroup.tsx
@@ -5,7 +5,7 @@ import "./HeadingGroup.scss"
 export interface HeadingGroupProps {
   /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
   heading: React.ReactNode
-  /** A string or element to display in an `p` tag (using `role="doc-subtitle"`) */
+  /** A string or element to display in an `p` tag (using `aria-roledescription="subtitle"`) */
   subheading: React.ReactNode
   /**
    * The heading level (1 through 6)
@@ -23,7 +23,7 @@ const HeadingGroup = (props: HeadingGroupProps) => {
   return (
     <hgroup className={classNames.join(" ")} role="group">
       <Heading priority={props.headingPriority ?? 2}>{props.heading}</Heading>
-      <p role="doc-subtitle">{props.subheading}</p>
+      <p aria-roledescription="subtitle">{props.subheading}</p>
     </hgroup>
   )
 }

--- a/src/headers/HeadingGroup.tsx
+++ b/src/headers/HeadingGroup.tsx
@@ -5,7 +5,7 @@ import "./HeadingGroup.scss"
 export interface HeadingGroupProps {
   /** A string or element to display in an `h2` tag (overridable via `headingPriority`) */
   heading: React.ReactNode
-  /** A string or element to display in an `p` */
+  /** A string or element to display in a `p` tag */
   subheading: React.ReactNode
   /**
    * The heading level (1 through 6)


### PR DESCRIPTION
# Pull Request Template

#61

## Description

Includes an update to the a11y label on the HeadingGroup from Detroit.

## How Can This Be Tested/Reviewed?

The change here is neither exactly what was was in UIC or is in Detroit - it removes the roles/descriptions from the p tag.

A journey: 

Previous method: `<p role="doc-subtitle">`
Detroit method: `<p aria-roledescription="subtitle">`

[Link that says previous method is questionable
](https://adrianroselli.com/2020/08/be-wary-of-doc-subtitle.html) and another great [sub-link from that page](https://www.tpgi.com/subheadings-subtitles-alternative-titles-and-taglines-in-html/), takeaways:
`Do not use h1-h6 to mark up Subheadings, subtitles, alternative titles and taglines in <hgroup>, use <p> elements.`

`Apply additional semantic information via ARIA with an abundance of caution as it may well end up being unwanted noise for users. Unless there is a specific need to convey additional information, for example, the subject matter is about Subheadings, subtitles, alternative titles and taglines in HTML or for someone proofreading the text, developers should allow the implicit, built-in semantics of HTML to do its job.`

`Whether the semantics of the <hgroup> and the specifics of child <p> elements are to be conveyed to users is a decision for the assistive technology developers in consultation with their users.`

[Link that says Detroit method is good](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/), but [Official documentation that says a role description is only valid if it has a role, but there isn't a great role for a subtitle
](https://accessibilityinsights.io/info-examples/web/aria-roledescription/) - while the role + role description seems like an accepted flow, our a11y linter was rightly throwing errors that the role description was not allowed on role-less p tag

Lighthouse said a p tag is okay in a very similar context in our last check-in and that additional "subtitle" context is not necessary and borderline noisy, so going with that!

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
