### PR TITLE
fix: align StepHeader with detroit updates

### DIFF
--- a/src/headers/StepHeader.scss
+++ b/src/headers/StepHeader.scss
@@ -3,7 +3,7 @@
   --circle-color: var(--bloom-color-primary);
   --circle-desktop-size: var(--bloom-s8);
   --circle-mobile-size: var(--bloom-s6);
-  --font-desktop-size: var(--bloom-font-size-lg);
+  --font-desktop-size: 1.125rem;
   --font-mobile-size: var(--bloom-font-size-base);
   --circle-x-padding: var(--bloom-s0_5);
   --title-spacing: var(--bloom-s1_5);

--- a/src/headers/StepHeader.scss
+++ b/src/headers/StepHeader.scss
@@ -8,6 +8,9 @@
   --circle-x-padding: var(--bloom-s0_5);
   --title-spacing: var(--bloom-s1_5);
   --label-font-weight: 600;
+  --font-family: var(--bloom-font-sans);
+
+  font-family: var(--font-family);
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/headers/StepHeader.tsx
+++ b/src/headers/StepHeader.tsx
@@ -7,6 +7,7 @@ export interface StepHeaderProps {
   stepPreposition: string
   stepLabeling: string[]
   className?: string
+  priority?: number
 }
 
 const StepHeader = ({
@@ -15,15 +16,18 @@ const StepHeader = ({
   stepPreposition,
   stepLabeling,
   className,
+  priority,
 }: StepHeaderProps) => {
+  const Tag = `h${priority || 2}` as keyof JSX.IntrinsicElements
+
   return (
-    <div className={`step-header ${className}`}>
-      <div className="step-header__circle-number">{currentStep}</div>
-      <div>{`${stepPreposition} ${totalSteps}`}</div>
-      <div className="step-header__title">
+    <Tag className={`step-header ${className || ""}`}>
+      <span className="step-header__circle-number">{currentStep}</span>
+      <span>{`${stepPreposition} ${totalSteps}`}</span>
+      <span className="step-header__title">
         {stepLabeling[Math.min(currentStep - 1, stepLabeling.length - 1)]}
-      </div>
-    </div>
+      </span>
+    </Tag>
   )
 }
 


### PR DESCRIPTION
# Pull Request Template

#64

## Description

This component is only used in Detroit, but looks like at some point we pulled it back to core, and then made improvements in Detroit.

## How Can This Be Tested/Reviewed?

Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/headers-step-header--basic-dynamic) to stories on [this PR](https://deploy-preview-51--storybook-bloom-dev.netlify.app/?path=/story/headers-hero--with-listings).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
