### PR TITLE
fix: align LanguageNav with Detroit updates

### DIFF
--- a/src/navigation/LanguageNav.scss
+++ b/src/navigation/LanguageNav.scss
@@ -1,32 +1,43 @@
 .language-bar {
-  @apply bg-gray-800;
+  --inner-max-width: var(--bloom-width-5xl);
+  --inner-width: inherit;
+  --inner-desktop-padding: inherit;
+  --inner-mobile-padding: inherit;
+
+  background-color: var(--bloom-color-gray-800);
 }
 
 .language-bar__inner {
-  @apply max-w-5xl;
-  @apply flex;
-  @apply justify-end;
+  max-width: var(--inner-max-width);
+  width: var(--inner-width);
+  display: flex;
+  justify-content: end;
   margin: auto;
+  padding: var(--inner-mobile-padding);
+
+  @media (min-width: $screen-md) {
+    padding: 0 var(--bloom-s3);
+    padding: var(--inner-desktop-padding);
+  }
 }
 
 .language-nav__list {
-  @apply flex;
+  display: flex;
 }
 
 .language-nav__list-button {
-  @apply py-2;
-  @apply px-3;
-  @apply text-gray-500;
-  @apply font-semibold;
-  @apply cursor-pointer;
-  @apply bg-none;
+  padding: var(--bloom-s2) var(--bloom-s3);
+  color: var(--bloom-color-gray-500);
+  font-weight: 600;
+  cursor: pointer;
+  background-color: transparent;
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px #fff, 0 0 3px 4px $tailwind-accent-cool;
+    box-shadow: 0 0 0 2px #fff, 0 0 3px 4px var(--bloom-color-accent-cool);
   }
 
   &.is-active {
-    @apply text-white;
+    color: var(--bloom-color-white);
   }
 }

--- a/src/navigation/LanguageNav.stories.tsx
+++ b/src/navigation/LanguageNav.stories.tsx
@@ -1,11 +1,14 @@
 import React from "react"
-
+import { BADGES } from "../../.storybook/constants"
 import { LanguageNav } from "./LanguageNav"
 import { text, withKnobs } from "@storybook/addon-knobs"
 
 export default {
-  title: "Navigation/LanguageNav",
+  title: "Navigation/LanguageNav 🚩",
   decorators: [(storyFn: any) => <div style={{ padding: "1rem" }}>{storyFn()}</div>, withKnobs],
+  parameters: {
+    badges: [BADGES.GEN2],
+  },
 }
 
 export const Default = () => (


### PR DESCRIPTION
# Pull Request Template

#69

## Description

Adds V2 styling for the component.

## How Can This Be Tested/Reviewed?

Compare the story on [dev](https://storybook.bloom.exygy.dev/?path=/story/navigation-languagenav--default) to the story on [this PR](https://deploy-preview-68--storybook-bloom-dev.netlify.app/?path=/story/navigation-languagenav--default).

You can also see it in some of the SiteHeader stories ([dev](https://storybook.bloom.exygy.dev/?path=/story/headers-site-header--with-language-and-mobile-notice) [PR](https://deploy-preview-68--storybook-bloom-dev.netlify.app/?path=/story/headers-site-header--with-language-and-mobile-notice)).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
