### PR TITLE
fix: align ListingCard with detroit updates

### DIFF
--- a/src/page_components/listing/ListingCard.scss
+++ b/src/page_components/listing/ListingCard.scss
@@ -4,16 +4,27 @@
   --max-width: var(--bloom-width-3xl);
   --max-width-large-screen: var(--bloom-width-5xl);
   --cell-padding: var(--bloom-s3);
+  --margin: var(--inter-row-gap) auto;
+  --card-tag-padding: var(--bloom-s3) var(--bloom-s5);
+  --card-tag-font-weight: inherit;
+
+  // margin: var(--card-tag-padding);
+  // margin: var(--card-tag-margin);
+  // font-weight: var(--card-tag-font-weight);
 
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   max-width: var(--max-width);
-  margin: var(--inter-row-gap) auto;
+  margin: var(--margin);
   position: relative;
 
   @media (min-width: $screen-lg) {
     --max-width: var(--max-width-large-screen);
+  }
+
+  &:first-of-type {
+    margin-top: var(--bloom-s12);
   }
 }
 
@@ -48,8 +59,10 @@
       justify-content: flex-start;
 
       .tag {
+        padding: var(--card-tag-padding);
         margin-bottom: var(--bloom-s2);
         margin-inline-end: var(--bloom-s2);
+        font-weight: var(--card-tag-font-weight);
 
         &:last-of-type {
           margin-inline-end: 0;
@@ -77,6 +90,11 @@
   margin-block-end: var(--bloom-s4);
 }
 
+.listings-row_footer_container {
+  display: flex;
+  flex-direction: column;
+}
+
 .listings-row_footer {
   display: flex;
   justify-content: flex-end;
@@ -87,6 +105,13 @@
   }
 }
 .listings-pill_header {
-  margin-bottom: var(--bloom-s3);
   margin-top: var(--bloom-s1);
+  margin-bottom: var(--bloom-s3);
+}
+
+.card-subheader {
+  font-family: var(--bloom-font-alt-sans);
+  color: var(--bloom-color-black);
+  font-size: var(--bloom-font-size-base);
+  margin-bottom: var(--bloom-s3);
 }

--- a/src/page_components/listing/ListingCard.scss
+++ b/src/page_components/listing/ListingCard.scss
@@ -111,3 +111,12 @@
   font-size: var(--bloom-font-size-base);
   margin-bottom: var(--bloom-s3);
 }
+
+.listing-card__tag-icon {
+  margin-right: var(--bloom-s2);
+
+  [dir="rtl"] & {
+    margin-right: 0;
+    margin-left: var(--bloom-s2);
+  }
+}

--- a/src/page_components/listing/ListingCard.scss
+++ b/src/page_components/listing/ListingCard.scss
@@ -8,10 +8,6 @@
   --card-tag-padding: var(--bloom-s3) var(--bloom-s5);
   --card-tag-font-weight: inherit;
 
-  // margin: var(--card-tag-padding);
-  // margin: var(--card-tag-margin);
-  // font-weight: var(--card-tag-font-weight);
-
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/src/page_components/listing/ListingCard.stories.tsx
+++ b/src/page_components/listing/ListingCard.stories.tsx
@@ -334,6 +334,7 @@ export const detroitStyle = () => {
       --normal-font-size: var(--bloom-font-size-base);
     }
     .listing-card-overrides .tag {
+      --card-tag-padding: var(--bloom-s2) var(--bloom-s3);
       --normal-padding: var(--bloom-s2) var(--bloom-s3);
       --label-weight: 700;
     }

--- a/src/page_components/listing/ListingCard.tsx
+++ b/src/page_components/listing/ListingCard.tsx
@@ -143,7 +143,7 @@ const ListingCard = (props: ListingCardProps) => {
                       size={"medium"}
                       symbol={cardTag.iconType}
                       fill={cardTag.iconColor ?? IconFillColors.primary}
-                      className={"me-2"}
+                      className={"listing-card__tag-icon"}
                     />
                   )}
                   {cardTag.text}

--- a/src/page_components/listing/ListingCard.tsx
+++ b/src/page_components/listing/ListingCard.tsx
@@ -18,6 +18,7 @@ export interface ListingCardHeader {
   customClass?: string
   styleType?: AppearanceStyleType
   isPillType?: boolean
+  priority?: number
 }
 
 export interface ListingFooterButton {
@@ -32,9 +33,14 @@ export interface ListingCardContentProps {
   tableHeader?: ListingCardHeader
   tableSubheader?: ListingCardHeader
 }
+
+export interface CardTag extends ImageTag {
+  shadeType?: AppearanceShadeType
+}
+
 export interface ListingCardProps {
   /** A list of tags to be rendered below the content header, a Tag component is rendered for each */
-  cardTags?: ImageTag[]
+  cardTags?: CardTag[]
   /** Custom content rendered in the content section above the table */
   children?: React.ReactElement
   /** An object containing fields that render optional headers above the content section's table */
@@ -112,18 +118,32 @@ const ListingCard = (props: ListingCardProps) => {
   const getContentHeader = () => {
     return (
       <div className="listings-row_headers">
-        {getHeader(contentProps?.contentHeader, 2, "largePrimary", "order-1")}
-        {getHeader(contentProps?.contentSubheader, 3, "mediumNormal", "order-2")}
+        {contentProps?.contentHeader &&
+          getHeader(
+            contentProps?.contentHeader,
+            contentProps?.contentHeader?.priority ?? 2,
+            "largePrimary",
+            "order-1"
+          )}
+        {contentProps?.contentSubheader && (
+          <p className="card-subheader order-2">{contentProps?.contentSubheader?.content}</p>
+        )}
+
         {cardTags && cardTags?.length > 0 && (
           <div className="listings-row_tags">
             {cardTags?.map((cardTag, index) => {
               return (
-                <Tag styleType={cardTag.styleType || AppearanceStyleType.warning} key={index}>
+                <Tag
+                  styleType={cardTag.styleType ?? AppearanceStyleType.warning}
+                  shade={cardTag?.shadeType}
+                  key={index}
+                >
                   {cardTag.iconType && (
                     <Icon
                       size={"medium"}
                       symbol={cardTag.iconType}
                       fill={cardTag.iconColor ?? IconFillColors.primary}
+                      className={"me-2"}
                     />
                   )}
                   {cardTag.text}
@@ -145,8 +165,18 @@ const ListingCard = (props: ListingCardProps) => {
               <hr className={"mb-2"} />
             )}
           <div className={"listings-row_headers"}>
-            {getHeader(contentProps?.tableHeader, 4, "smallWeighted")}
-            {getHeader(contentProps?.tableSubheader, 5, "smallNormal")}
+            {contentProps?.tableHeader &&
+              getHeader(
+                contentProps?.tableHeader,
+                contentProps?.tableHeader?.priority ?? 3,
+                "smallWeighted"
+              )}
+
+            {contentProps?.tableSubheader?.content && (
+              <p className="text__small-normal" aria-roledescription="subtitle">
+                {contentProps?.tableSubheader?.content}
+              </p>
+            )}
           </div>
           {children && children}
           {tableProps && (tableProps.data || tableProps.stackedData) && (
@@ -159,7 +189,7 @@ const ListingCard = (props: ListingCardProps) => {
             </>
           )}
         </div>
-        <div className={"flex flex-col"}>
+        <div className={"listings-row_footer_container"}>
           {footerContent && footerContent}
           {footerButtons && footerButtons?.length > 0 && (
             <div className={footerContainerClass ?? "listings-row_footer"}>

--- a/src/page_components/listing/ListingCard.tsx
+++ b/src/page_components/listing/ListingCard.tsx
@@ -173,9 +173,7 @@ const ListingCard = (props: ListingCardProps) => {
               )}
 
             {contentProps?.tableSubheader?.content && (
-              <p className="text__small-normal" aria-roledescription="subtitle">
-                {contentProps?.tableSubheader?.content}
-              </p>
+              <p className="text__small-normal">{contentProps?.tableSubheader?.content}</p>
             )}
           </div>
           {children && children}


### PR DESCRIPTION
# Pull Request Template

#87

## Description

Adds a few new CSS overrides, allows for a custom header priority, and changes the sub-subheader into a p tag for better a11y.

## How Can This Be Tested/Reviewed?

QA Notes:
Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/page-components-listing-card--with-standard-table) and on [this PR](https://deploy-preview-79--storybook-bloom-dev.netlify.app/?path=/story/page-components-listing-card--with-standard-table).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
