### PR TITLE
fix: align ListingDetailHeader with detroit updates

### DIFF
--- a/src/global/app-css.scss
+++ b/src/global/app-css.scss
@@ -54,7 +54,6 @@ main {
 @import "mixins.scss";
 @import "markdown.scss";
 @import "text.scss";
-@import "headers.scss";
 @import "blocks.scss";
 @import "accordion.scss";
 @import "accessibility.scss";

--- a/src/page_components/listing/ContentAccordion.scss
+++ b/src/page_components/listing/ContentAccordion.scss
@@ -32,3 +32,9 @@
 .accordion-gray-theme__bar.accordion-open {
   border-radius: 8px 8px 0px 0px;
 }
+
+.toggle-header-content {
+  @apply font-sans;
+  @apply text-sm;
+  @apply text-gray-800;
+}

--- a/src/page_components/listing/ListingDetailHeader.scss
+++ b/src/page_components/listing/ListingDetailHeader.scss
@@ -90,7 +90,7 @@
 }
 
 .detail-header__subtitle {
-  @apply text-tiny;
+  font-size: var(--bloom-font-size-sm);
 
   @screen md {
     @apply text-gray-800;

--- a/src/page_components/listing/ListingDetailHeader.scss
+++ b/src/page_components/listing/ListingDetailHeader.scss
@@ -4,8 +4,9 @@
   --subtitle-mobile-font-size: var(--bloom-font-size-sm);
   --title-desktop-font-size: var(--bloom-font-size-2xl);
   --title-mobile-font-size: var(--bloom-font-size-sm);
-
-  display: relative;
+  --title-desktop-font-family: var(--bloom-font-serif);
+  --title-mobile-font-family: var(--bloom-font-alt-sans);
+  position: relative;
   padding: var(--bloom-s4) var(--bloom-s4) var(--bloom-s6) var(--bloom-s4);
   border-bottom: 1px solid var(--bloom-color-gray-400);
   color: var(--text-color);
@@ -61,7 +62,7 @@
     }
 
     @media (min-width: $screen-md) {
-      display: hidden;
+      display: none;
     }
 
     svg {
@@ -72,13 +73,13 @@
 }
 
 .detail-header__title {
-  font-family: var(--bloom-font-alt-sans);
+  font-family: var(--title-mobile-font-family);
   text-transform: uppercase;
   font-size: var(--title-mobile-font-size);
   letter-spacing: 0.1rem;
   color: var(--text-color);
   @media (min-width: $screen-md) {
-    font-family: var(--bloom-font-serif);
+    font-family: var(--title-desktop-font-family);
     font-size: var(--title-desktop-font-size);
     text-transform: none;
     letter-spacing: 0rem;

--- a/src/page_components/listing/ListingDetailHeader.scss
+++ b/src/page_components/listing/ListingDetailHeader.scss
@@ -1,4 +1,3 @@
-// Listing Detail
 .detail-header {
   @apply relative;
   @apply pr-4;
@@ -8,6 +7,8 @@
   @apply border-b;
   @apply border-gray-400;
   @apply text-primary-darker;
+  @apply flex;
+  @apply justify-start;
 
   @screen md {
     @apply pt-0;
@@ -22,9 +23,18 @@
   @apply absolute;
   @apply w-12;
   @apply mr-2;
+  @apply ml-0;
 
   @screen md {
     @apply left-0;
+    @apply ml-1;
+  }
+}
+
+.detail-header__image-container {
+  width: auto;
+  [dir="rtl"] & {
+    width: var(--bloom-s14);
   }
 }
 
@@ -37,10 +47,19 @@
     @apply border-primary;
   }
 
+  [dir="rtl"] & {
+    margin-right: var(--bloom-s4);
+  }
+
   .ui-icon {
     @apply absolute;
     top: 1rem;
     right: 1rem;
+
+    [dir="rtl"] & {
+      left: 1rem;
+      right: auto;
+    }
 
     @screen md {
       @apply hidden;
@@ -71,23 +90,9 @@
 }
 
 .detail-header__subtitle {
-  @apply text-sm;
+  @apply text-tiny;
 
   @screen md {
-    @apply text-gray-750;
+    @apply text-gray-800;
   }
-}
-
-.toggle-header {
-  @apply bg-primary-light;
-  @apply p-4;
-  @apply border-b;
-  @apply border-primary;
-  display: flex;
-  justify-content: space-between;
-}
-.toggle-header-content {
-  @apply font-sans;
-  @apply text-sm;
-  @apply text-gray-800;
 }

--- a/src/page_components/listing/ListingDetailHeader.scss
+++ b/src/page_components/listing/ListingDetailHeader.scss
@@ -1,33 +1,33 @@
 .detail-header {
-  @apply relative;
-  @apply pr-4;
-  @apply pb-6;
-  @apply pl-4;
-  @apply pt-4;
-  @apply border-b;
-  @apply border-gray-400;
-  @apply text-primary-darker;
-  @apply flex;
-  @apply justify-start;
+  --text-color: var(--bloom-color-primary-darker);
+  --subtitle-desktop-font-size: var(--bloom-font-size-sm);
+  --subtitle-mobile-font-size: var(--bloom-font-size-sm);
+  --title-desktop-font-size: var(--bloom-font-size-2xl);
+  --title-mobile-font-size: var(--bloom-font-size-sm);
 
-  @screen md {
-    @apply pt-0;
-    @apply pb-8;
-    @apply text-xs;
-    @apply border-none;
-    @apply text-gray-800;
+  display: relative;
+  padding: var(--bloom-s4) var(--bloom-s4) var(--bloom-s6) var(--bloom-s4);
+  border-bottom: 1px solid var(--bloom-color-gray-400);
+  color: var(--text-color);
+  display: flex;
+  justify-content: start;
+
+  @media (min-width: $screen-md) {
+    padding-top: 0;
+    padding-bottom: var(--bloom-s8);
+    border: none;
+    color: var(--bloom-color-gray-800);
   }
 }
 
 .detail-header__image {
-  @apply absolute;
-  @apply w-12;
-  @apply mr-2;
-  @apply ml-0;
+  position: absolute;
+  width: var(--bloom-s12);
+  margin-right: var(--bloom-s2);
+  margin-left: 0;
 
-  @screen md {
-    @apply left-0;
-    @apply ml-1;
+  @media (min-width: $screen-md) {
+    left: 0;
   }
 }
 
@@ -39,12 +39,11 @@
 }
 
 .detail-header__hgroup {
-  @apply ml-12;
-  @apply pl-4;
+  margin-left: var(--bloom-s12);
+  padding-left: var(--bloom-s4);
 
-  @screen md {
-    @apply border-l-2;
-    @apply border-primary;
+  @media (min-width: $screen-md) {
+    border-left: 2px solid var(--bloom-color-primary);
   }
 
   [dir="rtl"] & {
@@ -52,47 +51,46 @@
   }
 
   .ui-icon {
-    @apply absolute;
-    top: 1rem;
-    right: 1rem;
+    position: absolute;
+    top: var(--bloom-s4);
+    right: var(--bloom-s4);
 
     [dir="rtl"] & {
-      left: 1rem;
+      left: var(--bloom-s4);
       right: auto;
     }
 
-    @screen md {
-      @apply hidden;
+    @media (min-width: $screen-md) {
+      display: hidden;
     }
 
     svg {
-      @apply w-3;
-      @apply h-3;
+      width: var(--bloom-s3);
+      height: var(--bloom-s3);
     }
   }
 }
 
 .detail-header__title {
-  @apply font-alt-sans;
-  @apply uppercase;
-  @apply text-sm;
-  @apply tracking-widest;
-  @apply text-primary-darker;
-
-  @screen md {
-    @apply text-black;
-    @apply font-serif;
-    @apply text-2xl;
-    @apply normal-case;
-    @apply tracking-normal;
-    @apply text-gray-950;
+  font-family: var(--bloom-font-alt-sans);
+  text-transform: uppercase;
+  font-size: var(--title-mobile-font-size);
+  letter-spacing: 0.1rem;
+  color: var(--text-color);
+  @media (min-width: $screen-md) {
+    font-family: var(--bloom-font-serif);
+    font-size: var(--title-desktop-font-size);
+    text-transform: none;
+    letter-spacing: 0rem;
+    color: var(--bloom-color-gray-950);
   }
 }
 
 .detail-header__subtitle {
-  font-size: var(--bloom-font-size-sm);
+  font-size: var(--subtitle-mobile-font-size);
 
-  @screen md {
-    @apply text-gray-800;
+  @media (min-width: $screen-md) {
+    color: var(--bloom-color-gray-800);
+    font-size: var(--subtitle-desktop-font-size);
   }
 }

--- a/src/page_components/listing/ListingDetailHeader.stories.tsx
+++ b/src/page_components/listing/ListingDetailHeader.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { ListingDetailHeader } from "./ListingDetailHeader"
+
+export default {
+  title: "Listing/ListingDetailHeader",
+}
+
+export const Default = () => {
+  return (
+    <div style={{ maxWidth: "500px" }}>
+      <ListingDetailHeader
+        imageAlt={"Building"}
+        imageSrc="https://housing.acgov.org/images/listing-eligibility.svg"
+        title={"Title"}
+        subtitle={"Subtitle"}
+      />
+    </div>
+  )
+}

--- a/src/page_components/listing/ListingDetailHeader.stories.tsx
+++ b/src/page_components/listing/ListingDetailHeader.stories.tsx
@@ -15,7 +15,7 @@ export const Default = () => {
     <div style={{ maxWidth: "500px" }}>
       <ListingDetailHeader
         imageAlt={"Building"}
-        imageSrc="https://housing.acgov.org/images/listing-eligibility.svg"
+        imageSrc="https://res.cloudinary.com/exygy/image/upload/w_400,c_limit,q_65/dev/listing-eligibility_advdnd.jpg"
         title={"Title"}
         subtitle={"Subtitle"}
       />

--- a/src/page_components/listing/ListingDetailHeader.stories.tsx
+++ b/src/page_components/listing/ListingDetailHeader.stories.tsx
@@ -1,9 +1,13 @@
 import * as React from "react"
+import { BADGES } from "../../../.storybook/constants"
 
 import { ListingDetailHeader } from "./ListingDetailHeader"
 
 export default {
-  title: "Listing/ListingDetailHeader",
+  title: "Listing/ListingDetailHeader 🚩",
+  parameters: {
+    badges: [BADGES.GEN2],
+  },
 }
 
 export const Default = () => {

--- a/src/page_components/listing/ListingDetailHeader.tsx
+++ b/src/page_components/listing/ListingDetailHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Icon } from "../../icons/Icon"
+import "./ListingDetailHeader.scss"
 
 export interface ListingDetailHeaderProps {
   imageAlt: string
@@ -12,8 +13,10 @@ export interface ListingDetailHeaderProps {
 }
 
 const ListingDetailHeader = (props: ListingDetailHeaderProps) => (
-  <header className={props.hideHeader ? "detail-header md:hidden" : "detail-header"}>
-    <img alt={props.imageAlt} className="detail-header__image " src={props.imageSrc} />
+  <header className={`detail-header ${props.hideHeader ? "md:hidden" : ""}`}>
+    <span className={"detail-header__image-container"}>
+      <img alt={props.imageAlt} className="detail-header__image " src={props.imageSrc} />
+    </span>
     <hgroup className="detail-header__hgroup">
       <h2 className="detail-header__title">{props.title}</h2>
       <span className="detail-header__subtitle">{props.subtitle}</span>

--- a/src/page_components/listing/ListingDetails.scss
+++ b/src/page_components/listing/ListingDetails.scss
@@ -1,0 +1,11 @@
+.details {
+  --desktop-width: 66.666667%;
+  --mobile-width: 100%;
+
+  width: var(--mobile-width);
+  @media (min-width: $screen-md) {
+    width: var(--desktop-width);
+    padding-right: var(--bloom-s8);
+    padding-top: var(--bloom-s8);
+  }
+}

--- a/src/page_components/listing/ListingDetails.scss
+++ b/src/page_components/listing/ListingDetails.scss
@@ -1,5 +1,5 @@
 .details {
-  --desktop-width: 66.666667%;
+  --desktop-width: calc(100% * (2 / 3));
   --mobile-width: 100%;
 
   width: var(--mobile-width);

--- a/src/page_components/listing/ListingDetails.tsx
+++ b/src/page_components/listing/ListingDetails.tsx
@@ -6,9 +6,10 @@ import {
   ResponsiveContentItemBody,
 } from "../../sections/ResponsiveContentList"
 import { ListingDetailHeader, ListingDetailHeaderProps } from "./ListingDetailHeader"
+import "./ListingDetails.scss"
 
 export const ListingDetails = (props: any) => (
-  <div className="w-full md:w-2/3 md:pr-8 md:pt-8">
+  <div className="details">
     <ResponsiveContentList>{props.children}</ResponsiveContentList>
   </div>
 )


### PR DESCRIPTION
# Pull Request Template

#81

## Description

Updates to V2 styling and pulls over a few RTL fixes. There will be a darker text color on the subtitle to meet AAA WCAG color constrast.

## How Can This Be Tested/Reviewed?

There is a new [story](https://deploy-preview-80--storybook-bloom-dev.netlify.app/?path=/story/listing-listingdetailheader-%F0%9F%9A%A9--default) added you can compare to a [prod listing](https://housing.acgov.org/listing/19c24c16-3ecc-4a0e-996e-76b507cd6d71/alexan_webster_2330_webster_street_oakland_ca).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
