### PR TITLE
fix: align GridSection with detroit updates

### DIFF
--- a/src/global/text.scss
+++ b/src/global/text.scss
@@ -97,7 +97,6 @@ h1.title {
   @apply block;
   @apply text-primary;
   @apply font-semibold;
-  cursor: pointer;
 }
 
 .pill {

--- a/src/global/text.scss
+++ b/src/global/text.scss
@@ -97,6 +97,7 @@ h1.title {
   @apply block;
   @apply text-primary;
   @apply font-semibold;
+  cursor: pointer;
 }
 
 .pill {

--- a/src/sections/GridSection.scss
+++ b/src/sections/GridSection.scss
@@ -1,4 +1,5 @@
 .grid-section {
+  --subtitle-font-size: var(--bloom-font-size-xs);
   .grid-item {
     @apply mb-4;
     overflow-wrap: break-word; // temp fix
@@ -27,6 +28,12 @@
   @apply flex-col;
 }
 
+.grid-section__header-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 .grid-section__title {
   @apply font-alt-sans;
   @apply text-xl;
@@ -43,7 +50,7 @@
   @apply uppercase;
   @apply font-alt-sans;
   @apply font-bold;
-  @apply text-xs;
+  font-size: var(--subtitle-font-size);
   @apply tracking-widest;
   @apply w-full;
   @apply mt-4;
@@ -69,4 +76,7 @@
   &.is-reversed {
     direction: rtl;
   }
+}
+.grid-section__edit-link {
+  margin-top: var(--bloom-s1);
 }

--- a/src/sections/GridSection.stories.tsx
+++ b/src/sections/GridSection.stories.tsx
@@ -74,6 +74,8 @@ export const FourColumnsEdit = () => (
     title="Very Long Section Title That Wraps on Mobile"
     subtitle="Subsection Title"
     columns={4}
+    edit="Edit"
+    editHref={"/edit"}
     tinted={true}
     inset={true}
   >

--- a/src/sections/GridSection.tsx
+++ b/src/sections/GridSection.tsx
@@ -22,12 +22,15 @@ const GridCell = (props: GridCellProps) => {
 
 export interface GridSectionProps {
   title?: React.ReactNode
+  edit?: string
+  editHref?: string
   subtitle?: string
   description?: string
   tinted?: boolean
   grid?: boolean
   columns?: number
   inset?: boolean
+  wrapperClassName?: string
   className?: string
   tightSpacing?: boolean
   reverse?: boolean
@@ -38,6 +41,7 @@ export interface GridSectionProps {
 const GridSection = (props: GridSectionProps) => {
   const sectionClasses = ["grid-section"]
   if (props.separator) sectionClasses.push("has-separator")
+  if (props.wrapperClassName) sectionClasses.push(props.wrapperClassName)
 
   const gridClasses = ["grid-section__inner"]
   const grid = typeof props.grid != "undefined" ? props.grid : true
@@ -63,15 +67,26 @@ const GridSection = (props: GridSectionProps) => {
 
   return (
     <section className={sectionClasses.join(" ")}>
-      {(props.title || props.subtitle) && (
-        <header className={headerClasses.join(" ")}>
-          {props.title && <h2 className="grid-section__title">{props.title}</h2>}
-          {props.subtitle && <h3 className={subtitleClasses.join(" ")}>{props.subtitle}</h3>}
-          {props.description && (
-            <span className={"grid-section__description"}>{props.description}</span>
-          )}
-        </header>
-      )}
+      <div className={"grid-section__header-container"}>
+        {(props.title || props.subtitle) && (
+          <div>
+            <header className={headerClasses.join(" ")}>
+              {props.title && <h2 className="grid-section__title">{props.title}</h2>}
+              {props.subtitle && <h3 className={subtitleClasses.join(" ")}>{props.subtitle}</h3>}
+              {props.description && (
+                <span className={"grid-section__description"}>{props.description}</span>
+              )}
+            </header>
+          </div>
+        )}
+        {props.edit && props.editHref && (
+          <span className="grid-section__edit-link">
+            <a className="edit-link" href={props.editHref}>
+              {props.edit}
+            </a>
+          </span>
+        )}
+      </div>
 
       <div className={gridClasses.join(" ")}>{props.children}</div>
     </section>


### PR DESCRIPTION
# Pull Request Template

#83

## Description

A few new CSS variables, and an optional edit button.

## How Can This Be Tested/Reviewed?


Compare the stories on [dev](https://storybook.bloom.exygy.dev/?path=/story/sections-grid-section--default-three-columns) and on [this PR](https://deploy-preview-82--storybook-bloom-dev.netlify.app/?path=/story/sections-grid-section--default-three-columns).

The edit story will look different, bc now there is actually an edit button :)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
