### PR TITLE
fix: add explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "sass-loader": "^10.0.3",
     "semantic-release": "19.0.5",
     "style-loader": "^1.1.3",
-    "tailwindcss-rtl": "^0.9.0",
     "ts-jest": "^26.4.1",
     "ts-loader": "^8.0.4",
     "typescript": "^4.9.4",
@@ -152,6 +151,7 @@
     "react-text-mask": "^5.4.3",
     "react-transition-group": "^4.4.1",
     "tailwindcss": "2.2.10",
+    "tailwindcss-rtl": "^0.9.0",
     "ts-jest": "^26.4.1",
     "typesafe-actions": "^5.1.0"
   },


### PR DESCRIPTION
Currently getting this error in core on the latest version: `Cannot find module 'tailwindcss-rtl'`
That was added as a dev dependency but it needs to be an explicit dependency, but also I'm not sure if this will fix the issue because linking locally from main works on core - it must not 100% reflect what it's like to pull in an external dependency