### PR TITLE
fix: more alignment for detroit components

### DIFF
--- a/src/blocks/FormCard.scss
+++ b/src/blocks/FormCard.scss
@@ -1,6 +1,7 @@
 @import "../global/mixins.scss";
 
 .form-card {
+  --title-font-size: var(--bloom-font-size-2xl);
   @apply bg-white;
 
   @screen md {
@@ -34,7 +35,7 @@
   @apply border-t-4;
   @apply border-primary;
   @apply leading-tight;
-  @apply text-2xl;
+  font-size: var(--title-font-size);
 
   @screen md {
     @apply mx-auto;

--- a/src/blocks/ImageCard.scss
+++ b/src/blocks/ImageCard.scss
@@ -10,6 +10,7 @@
   --tags-justify-desktop: flex-start;
   --grid-gap-mobile: var(--bloom-s2);
   --grid-gap-desktop: var(--bloom-s4);
+  --leader-width: var(--bloom-width-2-3rd);
 
   position: relative;
 }
@@ -151,7 +152,7 @@
   width: 100%;
 
   @media (min-width: $screen-md) {
-    width: var(--bloom-width-2-3rd);
+    width: var(--leader-width);
     padding-block-start: var(--bloom-s8);
     padding-inline-end: var(--bloom-s8);
   }

--- a/src/blocks/InfoCard.scss
+++ b/src/blocks/InfoCard.scss
@@ -12,6 +12,7 @@
   --title-text-transform-lighter: none;
   --title-letter-spacing: 0.025em;
   --title-letter-spacing-lighter: 0;
+  --content-font-size: inherit;
 
   padding: var(--padding);
   border-color: var(--border-color);
@@ -63,4 +64,8 @@
   @media (min-width: 440px) {
     flex: 1 1 45%;
   }
+}
+
+.info-card__content {
+  font-size: var(--content-font-size);
 }

--- a/src/blocks/InfoCard.tsx
+++ b/src/blocks/InfoCard.tsx
@@ -31,7 +31,7 @@ const InfoCard = (props: InfoCardProps) => {
         {props.subtitle && <span className={"text-sm text-gray-700"}>{props.subtitle}</span>}
       </div>
       {typeof props.children == "string" ? (
-        <div className="markdown">
+        <div className="info-card__content markdown">
           <Markdown options={{ disableParsingRawHTML: true }} children={props.children} />
         </div>
       ) : (

--- a/src/blocks/InfoCard.tsx
+++ b/src/blocks/InfoCard.tsx
@@ -31,7 +31,7 @@ const InfoCard = (props: InfoCardProps) => {
         {props.subtitle && <span className={"text-sm text-gray-700"}>{props.subtitle}</span>}
       </div>
       {typeof props.children == "string" ? (
-        <div className="info-card__content markdown">
+        <div className="markdown info-card__content markdown">
           <Markdown options={{ disableParsingRawHTML: true }} children={props.children} />
         </div>
       ) : (

--- a/src/blocks/InfoCard.tsx
+++ b/src/blocks/InfoCard.tsx
@@ -31,7 +31,7 @@ const InfoCard = (props: InfoCardProps) => {
         {props.subtitle && <span className={"text-sm text-gray-700"}>{props.subtitle}</span>}
       </div>
       {typeof props.children == "string" ? (
-        <div className="markdown info-card__content markdown">
+        <div className="markdown info-card__content">
           <Markdown options={{ disableParsingRawHTML: true }} children={props.children} />
         </div>
       ) : (

--- a/src/global/blocks.scss
+++ b/src/global/blocks.scss
@@ -96,7 +96,7 @@ details.disclosure {
 
 .aside-block__conjunction {
   @apply relative;
-  @apply -top;
+  top: -0.8rem;
   @apply px-1;
   @apply uppercase;
   @apply text-primary-dark;

--- a/src/global/forms.scss
+++ b/src/global/forms.scss
@@ -4,6 +4,7 @@
   --bordered-vertical-padding: var(--bloom-s4);
   --bordered-leftward-padding: 2.875rem;
   --bordered-checked-bg-color: var(--bloom-color-gray-100);
+  --input-prepend-font-size: var(--bloom-font-size-xl);
 
   margin-bottom: 1.25rem;
 
@@ -93,8 +94,8 @@
       @apply px-3;
       @apply py-2;
       @apply items-center;
-      @apply text-lg;
       background: transparent;
+      font-size: var(--input-prepend-font-size);
     }
 
     .prepend + input[aria-invalid="false"] {

--- a/src/global/forms.scss
+++ b/src/global/forms.scss
@@ -93,7 +93,7 @@
       @apply px-3;
       @apply py-2;
       @apply items-center;
-      @apply text-xl;
+      @apply text-lg;
       background: transparent;
     }
 

--- a/src/global/mixins.scss
+++ b/src/global/mixins.scss
@@ -129,7 +129,7 @@
   }
 
   &.is-borderless {
-    color: var(filled-borderless, var(--bloom-color-primary));
+    color: var(--borderless-filled-color, var(--bloom-color-primary));
     border-color: transparent;
     background: transparent;
 

--- a/src/global/mixins.scss
+++ b/src/global/mixins.scss
@@ -129,7 +129,7 @@
   }
 
   &.is-borderless {
-    color: var(--bloom-color-primary);
+    color: var(filled-borderless, var(--bloom-color-primary));
     border-color: transparent;
     background: transparent;
 

--- a/src/headers/PageHeader.scss
+++ b/src/headers/PageHeader.scss
@@ -9,6 +9,7 @@
   --inverse-text-color: var(--bloom-color-white);
   --title-font-size-desktop: var(--bloom-font-size-4xl);
   --title-font-size-mobile: var(--bloom-font-size-2xl);
+  --title-font-weight: inherit;
   --padding-desktop: var(--bloom-s10) 0;
   --padding-mobile: var(--bloom-s8) 0;
 
@@ -53,6 +54,7 @@
   text-align: center;
   font-family: var(--text-font-family);
   word-break: break-word;
+  font-weight: var(--title-font-weight);
 
   @media (min-width: $screen-md) {
     font-size: var(--title-font-size-desktop);
@@ -64,4 +66,7 @@
   text-align: center;
   font-family: var(--text-font-family);
   max-width: var(--bloom-width-5xl);
+  @media (min-width: $screen-md) {
+    text-align: left;
+  }
 }

--- a/src/page_components/listing/AdditionalFees.tsx
+++ b/src/page_components/listing/AdditionalFees.tsx
@@ -28,26 +28,33 @@ const AdditionalFees = ({
   if (!deposit && !applicationFee && !hasFooter) return <></>
   return (
     <InfoCard title={strings.sectionHeader} className="bg-gray-100 border-0">
-      <GridSection columns={2} className={`${hasFooter && "mb-5"}`}>
-        {applicationFee && (
-          <GridCell>
-            <div className="text-base">{strings.applicationFee}</div>
-            <div className="text-xl font-bold">{applicationFee}</div>
-            {strings.applicationFeeSubtext?.map((appFeeSubtext, index) => (
-              <div key={index} className="text-sm">{appFeeSubtext}</div>
-            ))}
-          </GridCell>
-        )}
-        {deposit && (
-          <GridCell>
-            <div className="text-base">{strings.deposit}</div>
-            <div className="text-xl font-bold">{deposit}</div>
-            {strings.depositSubtext?.map((depositSubtext, index) => (
-              <div className="text-sm" key={index}>{depositSubtext}</div>
-            ))}
-          </GridCell>
-        )}
-      </GridSection>
+      {(applicationFee || deposit) && (
+        <GridSection columns={2} className={`${hasFooter ? "mb-5" : ""}`}>
+          {applicationFee && (
+            <GridCell>
+              <div className="text-base">{strings.applicationFee}</div>
+              <div className="text-xl font-bold">{applicationFee}</div>
+              {strings.applicationFeeSubtext?.map((appFeeSubtext, index) => (
+                <div key={index} className="text-sm">
+                  {appFeeSubtext}
+                </div>
+              ))}
+            </GridCell>
+          )}
+          {deposit && (
+            <GridCell>
+              <div className="text-base">{strings.deposit}</div>
+              <div className="text-xl font-bold">{deposit}</div>
+              {strings.depositSubtext?.map((depositSubtext, index) => (
+                <div className="text-sm" key={index}>
+                  {depositSubtext}
+                </div>
+              ))}
+            </GridCell>
+          )}
+        </GridSection>
+      )}
+
       {hasFooter && (
         <div className="info-card__columns text-xs">
           {footerContent?.map((elem, idx) => (

--- a/src/tables/GroupedTable.tsx
+++ b/src/tables/GroupedTable.tsx
@@ -17,7 +17,12 @@ export const GroupedTable = (props: GroupedTableProps) => {
 
   const headerLabels = Object.values(headers).map((col, index) => {
     const uniqKey = process.env.NODE_ENV === "test" ? `header-${index}` : nanoid()
-    return <th key={uniqKey}>{col as string}</th>
+    return (
+      <th key={uniqKey}>
+        {typeof col === "string" ? col : col.name}{" "}
+        {col instanceof Object && col.icon ? col.icon : null}
+      </th>
+    )
   })
 
   const body: React.ReactNode[] = []
@@ -61,7 +66,7 @@ export const GroupedTable = (props: GroupedTableProps) => {
       })
 
       body.push(
-        <tr id={rowKey} key={rowKey} className={`group-${groupClassName}`}>
+        <tr id={rowKey} key={rowKey} className={`group-${groupClassName || ""}`}>
           {cols}
         </tr>
       )

--- a/src/tables/StandardTable.tsx
+++ b/src/tables/StandardTable.tsx
@@ -10,6 +10,7 @@ export interface TableHeadersOptions {
   name: string
   mobileReplacement?: string
   className?: string
+  icon?: React.ReactNode
 }
 export interface TableHeaders {
   [key: string]: string | TableHeadersOptions
@@ -173,7 +174,7 @@ export const StandardTable = (props: StandardTableProps) => {
         <Cell
           key={`${dataIndex}-order-draggable`}
           headerLabel={props.strings?.sortString ?? t("t.sort")}
-          className={`pl-5 ${cellClassName ?? ""}`}
+          className={`pl-5 ${cellClassName || ""}`}
         >
           {dataIndex + 1}
         </Cell>


### PR DESCRIPTION
This PR includes a handful of new CSS variables that we need to customize UIC that were missed in the first round.

There is also one bug fix around page header mobile alignment, a fix around rendering an empty section in additional fees, and the ability to add an icon in a table header (Detroit's AMI icon).