### PR TITLE
fix: Footer links are stacked on top of each other

### DIFF
--- a/src/navigation/FooterNav.scss
+++ b/src/navigation/FooterNav.scss
@@ -1,6 +1,7 @@
 .footer-sock {
   --background-color: var(--bloom-color-gray-900);
   --copyright-text-color: var(--bloom-color-gray-500);
+  --copyright-width: auto;
 
   background-color: var(--background-color);
   @apply py-8;
@@ -36,6 +37,7 @@
     width: auto;
     flex-shrink: 0;
     @screen lg {
+      width: var(--copyright-width);
       @apply text-left;
     }
   }

--- a/src/navigation/FooterNav.scss
+++ b/src/navigation/FooterNav.scss
@@ -36,7 +36,6 @@
     width: auto;
     flex-shrink: 0;
     @screen lg {
-      @apply w-full;
       @apply text-left;
     }
   }


### PR DESCRIPTION
# Pull Request Template

#93  

## Description

It removes full width on large screen from footer copyright (couldn't find any scenario when we need it). Previously footer copyright pushed out rest to right side.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

Go to footer, on large screen it should display all in one horizontal line (if there is enough space) 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
