### PR TITLE
fix: move leader-width for image card

### DIFF
--- a/src/blocks/ImageCard.scss
+++ b/src/blocks/ImageCard.scss
@@ -10,7 +10,6 @@
   --tags-justify-desktop: flex-start;
   --grid-gap-mobile: var(--bloom-s2);
   --grid-gap-desktop: var(--bloom-s4);
-  --leader-width: var(--bloom-width-2-3rd);
 
   position: relative;
 }
@@ -149,6 +148,7 @@
 }
 
 .image-card--leader {
+  --leader-width: var(--bloom-width-2-3rd);
   width: 100%;
 
   @media (min-width: $screen-md) {


### PR DESCRIPTION
## Description

There is a bug in the Image Card when pulling the latest changes into core. there was a new CSS variable called --leader-width added to the ImageCard.scss. The issue we run into is the .image-card--leader is higher in the DOM than the place where the --leader-width variable is getting set (.image-card)

This fixes the issue by moving the `--leader-width` variable to the `.image-card--leader` class.

Long term I don't think the `image-card--leader` should be in ui-components at all as its usage is only used in bloom and not really part of the imageCard

Issue example 1
![image](https://user-images.githubusercontent.com/42942267/234671008-253e948f-cf91-488a-9394-e8d07114b826.png)

Issue example 2
![image](https://user-images.githubusercontent.com/42942267/234671926-01970e35-73c8-484f-a744-fbff13b1ebc0.png)


## How Can This Be Tested/Reviewed?

This can only be tested by linking the change in bloom and going to listings detail page.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
