### PR TITLE
fix: focus on modal header on open

### DIFF
--- a/src/overlays/Modal.tsx
+++ b/src/overlays/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import "./Modal.scss"
 import { Icon, IconFillColors } from "../icons/Icon"
 import { Overlay, OverlayProps } from "./Overlay"
@@ -22,12 +22,15 @@ export interface ModalProps extends Omit<OverlayProps, "children"> {
 }
 
 const ModalHeader = (props: { title: string; uniqueId?: string; className?: string }) => {
+  const modalHeader = useRef<HTMLHeadingElement>(null)
+  useEffect(() => modalHeader?.current?.focus(), [props.title])
+
   const classNames = ["modal__title"]
   if (props.className) classNames.push(props.className)
   return (
     <>
       <header className="modal__header">
-        <h1 className={classNames.join(" ")} id={props.uniqueId}>
+        <h1 ref={modalHeader} tabIndex={-1} className={classNames.join(" ")} id={props.uniqueId}>
           {props.title}
         </h1>
       </header>


### PR DESCRIPTION
A part of Detroit alignment, brings [this Detroit PR ](https://github.com/CityOfDetroit/bloom/pull/1558) into UIC (details in that PR!).