### PR TITLE
fix: add frontend validation to preference address form fields

### DIFF
--- a/src/helpers/preferences.tsx
+++ b/src/helpers/preferences.tsx
@@ -1,14 +1,6 @@
 import React from "react"
 import { UseFormMethods } from "react-hook-form"
-import {
-  t,
-  GridSection,
-  ViewItem,
-  GridCell,
-  Field,
-  Select,
-  resolveObject,
-} from "../../"
+import { t, GridSection, ViewItem, GridCell, Field, Select, resolveObject } from "../../"
 
 type FormAddressProps = {
   subtitle: string
@@ -40,9 +32,13 @@ export const FormAddress = ({
               label={t("application.contact.streetAddress")}
               placeholder={t("application.contact.streetAddress")}
               register={register}
-              validation={{ required }}
+              validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.street`, errors)}
-              errorMessage={t("errors.streetError")}
+              errorMessage={
+                errors?.length && errors[`${dataKey}.street`] === "maxLength"
+                  ? t("errors.maxLength")
+                  : t("errors.streetError")
+              }
               readerOnly
             />
           </ViewItem>
@@ -56,6 +52,9 @@ export const FormAddress = ({
               placeholder={t("application.contact.apt")}
               register={register}
               readerOnly
+              error={!!resolveObject(`${dataKey}.street2`, errors)}
+              validation={{ maxLength: 64 }}
+              errorMessage={t("errors.maxLength")}
             />
           </ViewItem>
         </GridCell>
@@ -68,9 +67,13 @@ export const FormAddress = ({
               label={t("application.contact.cityName")}
               placeholder={t("application.contact.cityName")}
               register={register}
-              validation={{ required }}
+              validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.city`, errors)}
-              errorMessage={t("errors.cityError")}
+              errorMessage={
+                errors?.length && errors[`${dataKey}.city`] === "maxLength"
+                  ? t("errors.maxLength")
+                  : t("errors.cityError")
+              }
               readerOnly
             />
           </ViewItem>
@@ -100,9 +103,13 @@ export const FormAddress = ({
               label={t("application.contact.zip")}
               placeholder={t("application.contact.zipCode")}
               register={register}
-              validation={{ required }}
+              validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.zipCode`, errors)}
-              errorMessage={t("errors.zipCodeError")}
+              errorMessage={
+                errors?.length && errors[`${dataKey}.zipCode`] === "maxLength"
+                  ? t("errors.maxLength")
+                  : t("errors.zipCodeError")
+              }
               readerOnly
             />
           </ViewItem>

--- a/src/helpers/preferences.tsx
+++ b/src/helpers/preferences.tsx
@@ -35,7 +35,7 @@ export const FormAddress = ({
               validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.street`, errors)}
               errorMessage={
-                errors?.length && errors[`${dataKey}.street`] === "maxLength"
+                resolveObject(`${dataKey}.street`, errors)?.type === "maxLength"
                   ? t("errors.maxLength")
                   : t("errors.streetError")
               }
@@ -70,7 +70,7 @@ export const FormAddress = ({
               validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.city`, errors)}
               errorMessage={
-                errors?.length && errors[`${dataKey}.city`] === "maxLength"
+                resolveObject(`${dataKey}.city`, errors)?.type === "maxLength"
                   ? t("errors.maxLength")
                   : t("errors.cityError")
               }
@@ -106,7 +106,7 @@ export const FormAddress = ({
               validation={{ required, maxLength: 64 }}
               error={!!resolveObject(`${dataKey}.zipCode`, errors)}
               errorMessage={
-                errors?.length && errors[`${dataKey}.zipCode`] === "maxLength"
+                resolveObject(`${dataKey}.zipCode`, errors)?.type === "maxLength"
                   ? t("errors.maxLength")
                   : t("errors.zipCodeError")
               }


### PR DESCRIPTION
We are still getting [application submission errors](https://exygy.slack.com/archives/C02G1S19QA2/p1685474689348509) with this message: `preferences.0.options.0.extraData.0.value.street must be shorter than or equal to 64 characters`.

We've made two fixes for this [in core recently](https://github.com/bloom-housing/bloom/pull/3413), but I think we missed this set of fields because they're over here. The backend has a 64 character validation on these fields and this is adding that validation to the frontend as well.

