### PR TITLE
fix: add aria-expanded to ExpandableText

### DIFF
--- a/src/actions/ExpandableText.tsx
+++ b/src/actions/ExpandableText.tsx
@@ -44,6 +44,7 @@ const moreLessButton = (
       className={classes.join(" ")}
       onClick={() => setExpanded(!expanded)}
       aria-label={strings.buttonAriaLabel}
+      aria-expanded={expanded}
     >
       {expanded ? strings?.readLess : strings?.readMore}
     </button>


### PR DESCRIPTION
# Pull Request Template

This PR addresses Bloom [#3490](https://github.com/bloom-housing/bloom/issues/3490) and DAHLIA [DAH-1482](https://sfgovdt.jira.com/browse/DAH-1482).

## Description

This PR adds the `aria-expanded` attribute to the ExpandableText component. 

## How Can This Be Tested/Reviewed?

This can be tested by using a screen reader to expand and close the component - listen for the "expanded" and "collapsed" announcements. The added presence of `aria-expanded` can be further confirmed with developer tools. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
