### PR TITLE
fix: trigger backend sorting on initial table load

### DIFF
--- a/src/tables/AgTable.tsx
+++ b/src/tables/AgTable.tsx
@@ -133,18 +133,9 @@ const AgTable = ({
     suppressNoRowsOverlay: data.loading,
   }
 
-  // update table items order on sort change
-  const initialLoadOnSort = useRef<boolean>(false)
-
   const onSortChange = useCallback(
     (columns: ColumnState[]) => {
       if (!setSort) return
-
-      // prevent multiple fetch on initial render
-      if (!initialLoadOnSort.current) {
-        initialLoadOnSort.current = true
-        return
-      }
 
       const sortedColumns = columns.filter((col) => !!col.sort)
 
@@ -197,11 +188,27 @@ const AgTable = ({
     sessionStorage.setItem(columnStateLsKey, columnStateJSON)
   }
 
+  const initialLoadOnSort = useRef<boolean>(false)
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onGridReady = (params: any) => {
     setGridColumnApi(params.columnApi)
     if (selectConfig?.setGridApi) {
       selectConfig.setGridApi(params.api)
+    }
+
+    // sort data on initial load if sort field present
+    if (!initialLoadOnSort.current) {
+      initialLoadOnSort.current = true
+      const initialSortColumn = columns.find((item: ColDef) => item?.sort) as ColDef
+      if (initialSortColumn && setSort && initialSortColumn.field) {
+        setSort([
+          {
+            orderBy: initialSortColumn.field,
+            orderDir: initialSortColumn.sort?.toUpperCase() || "asc",
+          },
+        ])
+      }
     }
   }
 


### PR DESCRIPTION
# Pull Request Template

[#3556](https://github.com/bloom-housing/bloom/issues/3556)

## Description

Previously first sort on new session was only frontend side. This PR removes code that blocked first sort request (so first in session click on sortable column header) and adds initial sort functionality that picks first `sort` field from `columns` array.

## How Can This Be Tested/Reviewed?

This is part of [#3556](https://github.com/bloom-housing/bloom/pull/3576) so should be tested also with those changes, but it should work without them.
On partners site go to listing applications tab `/listings/[id]/applications`. By default `application submitted date` should be properly sorted. Other sortable fields should trigger backend sort on first click (table will twitch, and request will be made).
Same for `listings`, but status will be default sort (on `3556/...`  core branch)
Check any other tables that uses `AgTable`

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
