### PR TITLE
fix: allow textarea validation

### DIFF
--- a/src/forms/Textarea.tsx
+++ b/src/forms/Textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import "./Textarea.scss"
 import { t } from "../helpers/translator"
-import { UseFormMethods } from "react-hook-form"
+import { UseFormMethods, RegisterOptions } from "react-hook-form"
 
 type WrapOptions = "soft" | "hard"
 
@@ -20,6 +20,7 @@ export interface TextareaProps {
   register?: UseFormMethods["register"]
   resize?: boolean
   rows?: number
+  validation?: RegisterOptions
   wrap?: WrapOptions
   readerOnly?: boolean
   inputProps?: Record<string, unknown>
@@ -52,7 +53,7 @@ export const Textarea = (props: TextareaProps) => {
         maxLength={props.maxLength ?? 1000}
         name={props.name}
         placeholder={props.placeholder ?? t("t.description")}
-        ref={props.register}
+        ref={props.register && props.register(props.validation)}
         rows={props.rows ?? 4}
         wrap={props.wrap ?? "soft"}
         title={props.label}


### PR DESCRIPTION
# Pull Request Template

#119 

## Description

Allows for the Textarea to receive validation.

## How Can This Be Tested/Reviewed?

Difficult to test outside of the context of an existing form which isn't something we have set up in stories. I have this linked locally with a new set of changes to listings approval that shows the validation comes through which I'm happy to demo if needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
