### PR TITLE
fix: hide application status when no content to display

### DIFF
--- a/src/notifications/ApplicationStatus.tsx
+++ b/src/notifications/ApplicationStatus.tsx
@@ -63,6 +63,8 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
     classNames.push(className)
   }
 
+  if (!content && !subContent) return null
+
   return (
     <div className={classNames.join(" ")}>
       {icon}


### PR DESCRIPTION
# Pull Request Template

[#3630](https://github.com/bloom-housing/bloom/issues/3630)

## Description

In `/listing/:id` For application status (blue block in top right) when there is nothing to display it will display nothing instead of empty component.

## How Can This Be Tested/Reviewed?

For hidden application status go to partners listing and set it to `application process` -> `How is the application review order determined?` -> `lottery`.
And empty `Application Due Date` (the one that is all the way down in application process tab). For rest variants it probably should be visible, but worth to check if i missed something.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
