### PR TITLE
fix: add className prop to StandardTable

### DIFF
--- a/src/tables/StandardTable.tsx
+++ b/src/tables/StandardTable.tsx
@@ -71,6 +71,8 @@ export interface StandardTableProps {
   headers: TableHeaders
   /** The table data passed as records of column name to cell data with optional settings */
   data?: StandardTableData
+  /** A class name applied to the wrapper of the table */
+  className?: string
   /** A class name applied to the root of the table */
   tableClassName?: string
   /** A class name applied to each cell */
@@ -257,7 +259,7 @@ export const StandardTable = (props: StandardTableProps) => {
   }
 
   return (
-    <div style={{ overflowX: "auto" }}>
+    <div style={{ overflowX: "auto" }} className={props.className}>
       <table id={props.id} aria-label={props.ariaLabel} className={tableClasses.join(" ")}>
         <thead>
           <tr>{headerLabels}</tr>


### PR DESCRIPTION
# Pull Request Template

[#44](https://github.com/bloom-housing/Bloom-Doorway/issues/44)

## Description

Adds className prop to StandardTable component to be able to use it in doorway.

## How Can This Be Tested/Reviewed?

[In this PR](https://github.com/metrotranscom/doorway/pull/367) we have that class utilised, so can be tested on that PR.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
