### PR TITLE
fix: mobile modal button visible

### DIFF
--- a/src/overlays/Modal.docs.mdx
+++ b/src/overlays/Modal.docs.mdx
@@ -35,4 +35,3 @@ You can apply CSS variables to the `.modal` selector to customize the appearance
 | `--modal-shadow`            | Box Shadow         | Shadow behind modal             | `--bloom-shadow-md`                                       |
 | `--modal-border`            | Border             | Border of modal                 | `var(--bloom-border-1) solid var(--bloom-color-gray-400)` |
 | `--footer-justify`          | Flex Justification | Footer alignment                | `normal`                                                  |
-| `--modal-fallback-padding`  | Size               | Modal bottom padding            | `bloom-s32`                                               |

--- a/src/overlays/Modal.docs.mdx
+++ b/src/overlays/Modal.docs.mdx
@@ -35,3 +35,4 @@ You can apply CSS variables to the `.modal` selector to customize the appearance
 | `--modal-shadow`            | Box Shadow         | Shadow behind modal             | `--bloom-shadow-md`                                       |
 | `--modal-border`            | Border             | Border of modal                 | `var(--bloom-border-1) solid var(--bloom-color-gray-400)` |
 | `--footer-justify`          | Flex Justification | Footer alignment                | `normal`                                                  |
+| `--modal-fallback-padding`  | Size               | Modal bottom padding            | `bloom-s32`                                               |

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -21,18 +21,19 @@
   --modal-shadow: var(--bloom-shadow-md);
   --modal-border: var(--bloom-border-1) solid var(--bloom-color-gray-400);
   --footer-justify: normal;
+  --max-height: 100vh;
   --overflow: auto;
   --width: 100vw;
   --modal-header-min-height: auto;
   --modal-margin-top: auto;
+  --modal-fallback-padding: var(--bloom-s32);
 
-  @supports (max-height: 80dvh) {
-    --max-height: 80dvh;
+  @supports (max-height: 100dvh) {
+    --max-height: 100dvh;
   }
   @supports not (max-height: 100dvh) {
-    --max-height: 100vh;
     @media (max-width: $screen-sm) {
-      padding-bottom: var(--bloom-s32);
+      padding-bottom: var(--modal-fallback-padding);
     }
   }
 

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -65,6 +65,7 @@
     }
   }
 }
+
 .modal__header {
   min-height: var(--modal-header-min-height);
 }

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -26,8 +26,8 @@
   --modal-header-min-height: auto;
   --modal-margin-top: auto;
 
-  @supports (max-height: 100dvh) {
-    --max-height: 100dvh;
+  @supports (max-height: 80dvh) {
+    --max-height: 80dvh;
   }
   @supports not (max-height: 100dvh) {
     @media (max-width: $screen-sm) {

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -30,6 +30,7 @@
     --max-height: 80dvh;
   }
   @supports not (max-height: 100dvh) {
+    --max-height: 100vh;
     @media (max-width: $screen-sm) {
       padding-bottom: var(--bloom-s32);
     }

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -26,16 +26,7 @@
   --width: 100vw;
   --modal-header-min-height: auto;
   --modal-margin-top: auto;
-  --modal-fallback-padding: var(--bloom-s32);
-
-  @supports (max-height: 100dvh) {
-    --max-height: 100dvh;
-  }
-  @supports not (max-height: 100dvh) {
-    @media (max-width: $screen-sm) {
-      padding-bottom: var(--modal-fallback-padding);
-    }
-  }
+  --modal-fallback-padding: var(--bloom-s20);
 
   overflow: var(--overflow);
   -webkit-overflow-scrolling: touch;
@@ -63,8 +54,18 @@
     max-height: calc(100vh - var(--bloom-s6));
     max-width: calc(100vw - var(--bloom-s6));
   }
+  // @supports (max-height: 100dvh) {
+  //   --max-height: 100dvh;
+  // }
+  // @supports not (max-height: 100dvh) {
+  @media (max-width: $screen-sm) {
+    padding-bottom: var(--modal-fallback-padding);
+    border: none;
+    box-shadow: none;
+    background-clip: content-box;
+    // }
+  }
 }
-
 .modal__header {
   min-height: var(--modal-header-min-height);
 }

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -26,7 +26,6 @@
   --width: 100vw;
   --modal-header-min-height: auto;
   --modal-margin-top: auto;
-  --modal-fallback-padding: var(--bloom-s20);
 
   overflow: var(--overflow);
   -webkit-overflow-scrolling: touch;
@@ -59,7 +58,7 @@
   }
   @supports not (max-height: 100dvh) {
     @media (max-width: $screen-sm) {
-      padding-bottom: var(--modal-fallback-padding);
+      padding-bottom: var(--bloom-s20);
       border: none;
       box-shadow: none;
       background-clip: content-box;

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -54,16 +54,16 @@
     max-height: calc(100vh - var(--bloom-s6));
     max-width: calc(100vw - var(--bloom-s6));
   }
-  // @supports (max-height: 100dvh) {
-  //   --max-height: 100dvh;
-  // }
-  // @supports not (max-height: 100dvh) {
-  @media (max-width: $screen-sm) {
-    padding-bottom: var(--modal-fallback-padding);
-    border: none;
-    box-shadow: none;
-    background-clip: content-box;
-    // }
+  @supports (max-height: 100dvh) {
+    --max-height: 100dvh;
+  }
+  @supports not (max-height: 100dvh) {
+    @media (max-width: $screen-sm) {
+      padding-bottom: var(--modal-fallback-padding);
+      border: none;
+      box-shadow: none;
+      background-clip: content-box;
+    }
   }
 }
 .modal__header {

--- a/src/overlays/Modal.scss
+++ b/src/overlays/Modal.scss
@@ -21,11 +21,19 @@
   --modal-shadow: var(--bloom-shadow-md);
   --modal-border: var(--bloom-border-1) solid var(--bloom-color-gray-400);
   --footer-justify: normal;
-  --max-height: 100vh;
   --overflow: auto;
   --width: 100vw;
   --modal-header-min-height: auto;
   --modal-margin-top: auto;
+
+  @supports (max-height: 100dvh) {
+    --max-height: 100dvh;
+  }
+  @supports not (max-height: 100dvh) {
+    @media (max-width: $screen-sm) {
+      padding-bottom: var(--bloom-s32);
+    }
+  }
 
   overflow: var(--overflow);
   -webkit-overflow-scrolling: touch;
@@ -49,8 +57,6 @@
     width: auto;
   }
 
-  max-height: 100vh;
-  max-width: 100vw;
   @media (min-width: $screen-md) {
     max-height: calc(100vh - var(--bloom-s6));
     max-width: calc(100vw - var(--bloom-s6));
@@ -147,4 +153,3 @@
     --modal-margin-top: var(--bloom-s6);
   }
 }
-

--- a/src/overlays/Modal.stories.tsx
+++ b/src/overlays/Modal.stories.tsx
@@ -254,30 +254,6 @@ export const ScrollableModalMinimalContent = () => {
   )
 }
 
-export const TransparentOverlayModal = () => (
-  <Modal
-    open={true}
-    title={text("Title", "Modal Title")}
-    ariaDescription={text("Aria Description", "Modal Description")}
-    hideCloseIcon={true}
-    actions={[
-      <Button
-        size={AppearanceSizeType.small}
-        onClick={noop}
-        styleType={AppearanceStyleType.primary}
-      >
-        {text("Action 2 Label", "Submit")}
-      </Button>,
-      <Button size={AppearanceSizeType.small} onClick={noop}>
-        {text("Action 1 Label", "Cancel")}
-      </Button>,
-    ]}
-    backdrop={false}
-  >
-    {text("Content", "Modal Content")}
-  </Modal>
-)
-
 export const ManyButtons = () => {
   const [openModal, setOpenModal] = useState(false)
 

--- a/src/overlays/Overlay.scss
+++ b/src/overlays/Overlay.scss
@@ -4,6 +4,9 @@
   --overlay-background-color: var(--bloom-color-gray-950);
   --overlay-opacity: 0.5;
   --overlay-height: 100vh;
+  @supports (height: 100dvh) {
+    --overlay-height: 100dvh;
+  }
 
   position: fixed;
   display: flex;

--- a/src/overlays/Overlay.scss
+++ b/src/overlays/Overlay.scss
@@ -4,9 +4,9 @@
   --overlay-background-color: var(--bloom-color-gray-950);
   --overlay-opacity: 0.5;
   --overlay-height: 100vh;
-  // @supports (height: 100dvh) {
-  //   --overlay-height: 100dvh;
-  // }
+  @supports (height: 100dvh) {
+    --overlay-height: 100dvh;
+  }
 
   position: fixed;
   display: flex;

--- a/src/overlays/Overlay.scss
+++ b/src/overlays/Overlay.scss
@@ -4,9 +4,9 @@
   --overlay-background-color: var(--bloom-color-gray-950);
   --overlay-opacity: 0.5;
   --overlay-height: 100vh;
-  @supports (height: 100dvh) {
-    --overlay-height: 100dvh;
-  }
+  // @supports (height: 100dvh) {
+  //   --overlay-height: 100dvh;
+  // }
 
   position: fixed;
   display: flex;


### PR DESCRIPTION
# Pull Request Template

#133 

## Description

This PR updates the modal and overlay components so that the actions in the footer will be visible on mobile devices whether the bottom search bar is up or not. This fix is made possible by using dvh which is supported by over 90% of users ([source](https://caniuse.com/mdn-css_types_length_viewport_percentage_units_dynamic)).

In the event that dvh is not supported, this PR includes a fallback solution which adds static padding which will keep full height modals actionable.

### Why does this work?

Setting the max height to 100dvh or dynamic view height prevents the modal buttons being blocked since it adjusts based on whether browser ux pieces are expanded or retracted (ie. search bar).

The fallback approach came to be since without dvh, we have to manually move the full-screen modal up to sit higher than browser ux pieces. This is achieved by the padding but then this causes non-fullscreeen modals to show a large footer. However with background-clip and removing the border and shadow, we can create that shift upward without detracting from the modals not taking up the full screen.

There is one edge case that wasn't able to be resolved based on the time-sensitivity of this fix and how rare this case is. The screen recroding below would only come up if a user had a mobile browser that didn't support dvh and was on a modal with overflow content (rather than scrollable). Also the screen recording doesn't account for the majority of the grayed out space being covered by the mobile browser's search or tool bar. 
https://github.com/bloom-housing/ui-components/assets/53269332/0d6e6fb6-f5b4-4b9c-9aaa-72d98770dff8

## How Can This Be Tested/Reviewed?

To test this directly, symlink this UIC to bloom and then run it locally. Access the public site on your mobile device and click into a listing with multiple images. Test Coliseum should work if you just seeded. Open the multi-photo modal and ensure the close button is visible at the bottom of your different browsers.


Also ensure the modal and image card stories are still functional on Storybook on both large and small devices. 

A small note that in my testing, I noticed that this doesn't work for the multiple image card story if accessing storybook on your phone and then clicking full screen (button below). I think this is because of how storybook canvas represents a full screen and believe that local instance is support enough of this fix.
<img width="763" alt="Screenshot 2023-11-30 at 5 16 04 PM" src="https://github.com/bloom-housing/ui-components/assets/53269332/cf7eb745-b8aa-48db-89bd-99c27c8f56ac">


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
