### PR TITLE
fix: remove LoadingOverlay alert role

### DIFF
--- a/src/overlays/LoadingOverlay.tsx
+++ b/src/overlays/LoadingOverlay.tsx
@@ -19,7 +19,7 @@ const LoadingOverlay = ({ isLoading, children }: LoadingOverlayProps) => {
     )
   }, [isLoading, children])
 
-  return { content }
+  return <>{content}</>
 }
 
 export { LoadingOverlay as default, LoadingOverlay }

--- a/src/overlays/LoadingOverlay.tsx
+++ b/src/overlays/LoadingOverlay.tsx
@@ -19,11 +19,7 @@ const LoadingOverlay = ({ isLoading, children }: LoadingOverlayProps) => {
     )
   }, [isLoading, children])
 
-  return (
-    <div role="alert" aria-live="assertive">
-      {content}
-    </div>
-  )
+  return { content }
 }
 
 export { LoadingOverlay as default, LoadingOverlay }


### PR DESCRIPTION
# Pull Request Template

This PR is for Issue #135. 

## Description

This removes the alert role from LoadingOverlay, which was causing screen readers to jump to the start of the overlay when interacting with operable components. The alert role should only be used sparingly for text content: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role

## How Can This Be Tested/Reviewed?

See Issue #135.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
