### PR TITLE
fix: allow subheader to return passed content without wrap

### DIFF
--- a/src/page_components/listing/ListingCard.stories.tsx
+++ b/src/page_components/listing/ListingCard.stories.tsx
@@ -110,6 +110,22 @@ export const WithHeaders = () => {
   )
 }
 
+export const WithElementSubHeader = () => {
+  return (
+    <ListingCard
+      imageCardProps={{ ...standardImageCardProps, href: undefined }}
+      tableProps={{ ...standardTableProps }}
+      footerButtons={[{ text: "See Details", href: "see-details-link", ariaHidden: true }]}
+      contentProps={{
+        contentHeader: { content: "Header", href: "listing-link" },
+        contentSubheader: { content: "Optional content subheader" },
+        tableHeader: { content: "Table Header with list subheader" },
+        tableSubheader: { content: <ul className="text__small-normal list-disc" ><li>Test</li><li>Test 2</li></ul>, isElement: true },
+      }}
+    />
+  )
+}
+
 export const WithPillHeader = () => {
   return (
     <ListingCard

--- a/src/page_components/listing/ListingCard.tsx
+++ b/src/page_components/listing/ListingCard.tsx
@@ -14,6 +14,7 @@ interface ListingCardTableProps extends StandardTableProps, StackedTableProps {}
 
 export interface ListingCardHeader {
   content: string | React.ReactNode
+  isElement?: boolean
   href?: string
   customClass?: string
   styleType?: AppearanceStyleType
@@ -115,6 +116,14 @@ const ListingCard = (props: ListingCardProps) => {
     }
   }
 
+  const getContentSubHeader = (subheader: ListingCardHeader, returnElement?: boolean) => {
+    return React.isValidElement(subheader.content) && returnElement ? (
+      subheader.content
+    ) : (
+      <p className="card-subheader order-2">{contentProps?.contentSubheader?.content}</p>
+    )
+  }
+
   const getContentHeader = () => {
     return (
       <div className="listings-row_headers">
@@ -125,10 +134,11 @@ const ListingCard = (props: ListingCardProps) => {
             "largePrimary",
             "order-1"
           )}
-        {contentProps?.contentSubheader && (
-          <p className="card-subheader order-2">{contentProps?.contentSubheader?.content}</p>
-        )}
-
+        {contentProps?.contentSubheader &&
+          getContentSubHeader(
+            contentProps?.contentSubheader,
+            contentProps?.contentSubheader?.isElement
+          )}
         {cardTags && cardTags?.length > 0 && (
           <div className="listings-row_tags">
             {cardTags?.map((cardTag, index) => {

--- a/src/page_components/listing/ListingCard.tsx
+++ b/src/page_components/listing/ListingCard.tsx
@@ -116,11 +116,11 @@ const ListingCard = (props: ListingCardProps) => {
     }
   }
 
-  const getContentSubHeader = (subheader: ListingCardHeader, returnElement?: boolean) => {
+  const getTableSubHeader = (subheader: ListingCardHeader, returnElement?: boolean) => {
     return React.isValidElement(subheader.content) && returnElement ? (
       subheader.content
     ) : (
-      <p className="card-subheader order-2">{contentProps?.contentSubheader?.content}</p>
+      <p className="text__small-normal">{subheader?.content}</p>
     )
   }
 
@@ -134,11 +134,9 @@ const ListingCard = (props: ListingCardProps) => {
             "largePrimary",
             "order-1"
           )}
-        {contentProps?.contentSubheader &&
-          getContentSubHeader(
-            contentProps?.contentSubheader,
-            contentProps?.contentSubheader?.isElement
-          )}
+        {contentProps?.contentSubheader && (
+          <p className="card-subheader order-2">{contentProps?.contentSubheader?.content}</p>
+        )}
         {cardTags && cardTags?.length > 0 && (
           <div className="listings-row_tags">
             {cardTags?.map((cardTag, index) => {
@@ -181,10 +179,11 @@ const ListingCard = (props: ListingCardProps) => {
                 contentProps?.tableHeader?.priority ?? 3,
                 "smallWeighted"
               )}
-
-            {contentProps?.tableSubheader?.content && (
-              <p className="text__small-normal">{contentProps?.tableSubheader?.content}</p>
-            )}
+            {contentProps?.tableSubheader &&
+              getTableSubHeader(
+                contentProps?.tableSubheader,
+                contentProps?.tableSubheader?.isElement
+              )}
           </div>
           {children && children}
           {tableProps && (tableProps.data || tableProps.stackedData) && (


### PR DESCRIPTION
# Pull Request Template

https://sfgovdt.jira.com/browse/DAH-1900


## Description

In DAHLIA, we sometimes use a list as content for the tableSubheader in  a listingCard. WIthout this change, the console throws this warning on local: 
`react-dom.development.js:86 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    at div`



## How Can This Be Tested/Reviewed?
- I added a storybook example.
- Here is a link to see an example: https://dahlia-full.herokuapp.com/listings/for-rent
 - run locally to see the warning
- Ensure that other bloom listing cards look the same as before

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.
- Storybook

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
