### PR TITLE
fix: allow for jsx elements on field error message

### DIFF
--- a/src/forms/Field.stories.tsx
+++ b/src/forms/Field.stories.tsx
@@ -26,6 +26,20 @@ export const TextFieldError = () => {
   )
 }
 
+export const TextFieldErrorElement = () => {
+  const { register } = useForm({ mode: "onChange" })
+  return (
+    <Field
+      register={register}
+      name={"Test Input"}
+      label={"Custom label"}
+      type={"text"}
+      error={true}
+      errorMessage={<div className="font-bold italic">Custom error message as element</div>}
+    />
+  )
+}
+
 export const CurrencyField = () => {
   const { register, getValues, setValue } = useForm({ mode: "onChange" })
   return (

--- a/src/forms/Field.tsx
+++ b/src/forms/Field.tsx
@@ -5,7 +5,7 @@ import { httpsRegex, urlRegex } from "../helpers/validators"
 
 export interface FieldProps {
   error?: boolean
-  errorMessage?: string
+  errorMessage?: string | JSX.Element
   className?: string
   controlClassName?: string
   caps?: boolean


### PR DESCRIPTION
# Pull Request Template

#155 

## Description

This change allows for the Field error message to either be a string or a JSX.Element. This will allow consumers to pass things like hyperlinks in the error message

## How Can This Be Tested/Reviewed?

This change extends the type definition of an optional prop. I have included a story to illustrate this new feature.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
