### PR TITLE
feat: allow only numbers when typing in the Date field

### DIFF
--- a/src/forms/DateField.stories.tsx
+++ b/src/forms/DateField.stories.tsx
@@ -10,9 +10,7 @@ export default {
 export const Default = () => {
   const { register, watch, errors, setValue, handleSubmit } = useForm()
 
-  const onSubmit = (data: any) => {
-    console.log(data)
-  }
+  const onSubmit = (data: any) => {}
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/forms/DateField.stories.tsx
+++ b/src/forms/DateField.stories.tsx
@@ -8,17 +8,28 @@ export default {
 }
 
 export const Default = () => {
-  const { register, watch, errors } = useForm({ mode: "onChange" })
+  const { register, watch, errors, setValue, handleSubmit } = useForm()
+
+  const onSubmit = (data: any) => {
+    console.log(data)
+  }
 
   return (
-    <DateField
-      id="appDueDate"
-      name="appDueDate"
-      label="Application Due Date"
-      required={true}
-      register={register}
-      watch={watch}
-      error={errors?.appDueDate}
-    />
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <DateField
+        id="appDueDate"
+        name="appDueDate"
+        label="Application Due Date"
+        register={register}
+        required={true}
+        setValue={setValue}
+        watch={watch}
+        error={errors?.appDueDate}
+      />
+      <br />
+      <button type="submit" className="button">
+        Submit
+      </button>
+    </form>
   )
 }

--- a/src/forms/DateField.tsx
+++ b/src/forms/DateField.tsx
@@ -23,6 +23,7 @@ export interface DateFieldProps {
   readerOnly?: boolean
   register: UseFormMethods["register"]
   required?: boolean
+  setValue?: UseFormMethods["setValue"]
   watch: UseFormMethods["watch"]
   dataTestId?: string
   strings?: {
@@ -34,6 +35,10 @@ export interface DateFieldProps {
     year?: string
     yearPlaceholder?: string
   }
+}
+
+export const maskNumber = (value: string) => {
+  return value.match(/\d+/g)?.join("")
 }
 
 const DateField = (props: DateFieldProps) => {
@@ -70,6 +75,11 @@ const DateField = (props: DateFieldProps) => {
           }}
           inputProps={{ maxLength: 2 }}
           register={register}
+          onChange={(e) => {
+            if (!props.setValue) return
+
+            props.setValue(getFieldName("month"), maskNumber(e.target.value))
+          }}
           dataTestId={props.dataTestId ? `${props.dataTestId}-month` : undefined}
         />
         <Field
@@ -91,6 +101,11 @@ const DateField = (props: DateFieldProps) => {
           }}
           inputProps={{ maxLength: 2 }}
           register={register}
+          onChange={(e) => {
+            if (!props.setValue) return
+
+            props.setValue(getFieldName("day"), maskNumber(e.target.value))
+          }}
           dataTestId={props.dataTestId ? `${props.dataTestId}-day` : undefined}
         />
         <Field
@@ -105,15 +120,21 @@ const DateField = (props: DateFieldProps) => {
             required: props.required,
             validate: {
               yearRange: (value: string) => {
-                if (props.required && value && parseInt(value) < 1900) return false
-                if (props.required && value && parseInt(value) > dayjs().year() + 10) return false
                 if (!props.required && !value?.length) return true
-                return true
+
+                const numVal = parseInt(value)
+                if (isNaN(numVal)) return false
+                return !(numVal < 1900 || numVal > dayjs().year() + 10)
               },
             },
           }}
           inputProps={{ maxLength: 4 }}
           register={register}
+          onChange={(e) => {
+            if (!props.setValue) return
+
+            props.setValue(getFieldName("year"), maskNumber(e.target.value))
+          }}
           dataTestId={props.dataTestId ? `${props.dataTestId}-year` : undefined}
         />
       </div>
@@ -121,7 +142,7 @@ const DateField = (props: DateFieldProps) => {
 
       {(error?.month || error?.day || error?.year) && (
         <div className="field error">
-          <span id={`${id}-error`} className="error-message">
+          <span id={`${id || "date-field"}-error`} className="error-message">
             {errorMessage ? errorMessage : props.strings?.dateError ?? t("errors.dateError")}
           </span>
         </div>


### PR DESCRIPTION
[Doorway #771](https://github.com/metrotranscom/doorway/issues/771)

## Description

This PR adds a change event handler to ensure only numbers can be typed into the date fields (requires the host page to pass along a `setValue` prop). It also improves some of the validation logic to be more robust.

## How Can This Be Tested/Reviewed?

[Storybook example](https://deploy-preview-157--storybook-bloom-dev.netlify.app/?path=/story/forms-date-field--default) (there's a test submit button as well to verify validation behavior)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
