### PR TITLE
feat: add input masking for numbers only in TimeField

### DIFF
--- a/src/forms/DateField.tsx
+++ b/src/forms/DateField.tsx
@@ -69,6 +69,7 @@ const DateField = (props: DateFieldProps) => {
             validate: {
               monthRange: (value: string) => {
                 if (!props.required && !value?.length) return true
+
                 return parseInt(value) > 0 && parseInt(value) <= 12
               },
             },
@@ -95,6 +96,7 @@ const DateField = (props: DateFieldProps) => {
             validate: {
               dayRange: (value: string) => {
                 if (!props.required && !value?.length) return true
+
                 return parseInt(value) > 0 && parseInt(value) <= 31
               },
             },

--- a/src/forms/TimeField.stories.tsx
+++ b/src/forms/TimeField.stories.tsx
@@ -8,7 +8,7 @@ export default {
 }
 
 export const Default = () => {
-  const { register, watch, errors } = useForm({ mode: "onChange" })
+  const { register, setValue, watch, errors } = useForm({ mode: "onChange" })
 
   return (
     <TimeField
@@ -17,6 +17,7 @@ export const Default = () => {
       name="time"
       required={true}
       register={register}
+      setValue={setValue}
       watch={watch}
       error={!!errors?.time}
     />

--- a/src/forms/TimeField.tsx
+++ b/src/forms/TimeField.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage } from "../notifications/ErrorMessage"
 import { Field } from "./Field"
 import { Select } from "../forms/Select"
 import { UseFormMethods } from "react-hook-form"
+import { maskNumber } from "./DateField"
 
 export type TimeFieldPeriod = "am" | "pm"
 
@@ -26,6 +27,7 @@ export type TimeFieldProps = {
   readerOnly?: boolean
   register: UseFormMethods["register"]
   required?: boolean
+  setValue?: UseFormMethods["setValue"]
   watch: UseFormMethods["watch"]
   seconds?: boolean
   dataTestId?: string
@@ -54,9 +56,10 @@ const TimeField = ({
   required = false,
   error,
   register,
+  setValue,
   watch,
   name,
-  id,
+  id = "time",
   label,
   labelClass,
   readerOnly,
@@ -66,16 +69,16 @@ const TimeField = ({
   dataTestId,
   strings,
 }: TimeFieldProps) => {
-  const fieldName = (baseName: string) => {
+  const getFieldName = (baseName: string) => {
     return [name, baseName].filter((item) => item).join(".")
   }
 
   // it prevents partial fill, all fields should be filled or nothing
   const [innerRequiredRule, setInnerRequiredRule] = useState(false)
 
-  const hoursField = watch(fieldName("hours"))
-  const minutesField = watch(fieldName("minutes"))
-  const secondsField = watch(fieldName("seconds"))
+  const hoursField = watch(getFieldName("hours"))
+  const minutesField = watch(getFieldName("minutes"))
+  const secondsField = watch(getFieldName("seconds"))
 
   useEffect(() => {
     const someFieldsFilled = hoursField || minutesField || secondsField
@@ -90,7 +93,7 @@ const TimeField = ({
       <legend className={labelClasses.join(" ")}>{label}</legend>
       <div className="field-group--date">
         <Field
-          name={fieldName("hours")}
+          name={getFieldName("hours")}
           label={strings?.hour ?? t("t.hour")}
           defaultValue={defaultValues?.hours ?? ""}
           readerOnly={true}
@@ -108,13 +111,18 @@ const TimeField = ({
           }}
           inputProps={{ maxLength: 2 }}
           register={register}
+          onChange={(e) => {
+            if (!setValue) return
+
+            setValue(getFieldName("hours"), maskNumber(e.target.value))
+          }}
           describedBy={`${id}-error`}
           disabled={disabled}
           dataTestId={dataTestId ? `${dataTestId}-hours` : undefined}
         />
 
         <Field
-          name={fieldName("minutes")}
+          name={getFieldName("minutes")}
           label={strings?.minutes ?? t("t.minutes")}
           defaultValue={defaultValues?.minutes ?? ""}
           readerOnly={true}
@@ -132,6 +140,11 @@ const TimeField = ({
           }}
           inputProps={{ maxLength: 2 }}
           register={register}
+          onChange={(e) => {
+            if (!setValue) return
+
+            setValue(getFieldName("minutes"), maskNumber(e.target.value))
+          }}
           describedBy={`${id}-error`}
           disabled={disabled}
           dataTestId={dataTestId ? `${dataTestId}-minutes` : undefined}
@@ -141,7 +154,7 @@ const TimeField = ({
           <Field
             label={strings?.seconds ?? t("t.seconds")}
             defaultValue={defaultValues?.seconds ?? ""}
-            name={fieldName("seconds")}
+            name={getFieldName("seconds")}
             readerOnly={true}
             placeholder="SS"
             error={error}
@@ -157,6 +170,11 @@ const TimeField = ({
             }}
             inputProps={{ maxLength: 2 }}
             register={register}
+            onChange={(e) => {
+              if (!setValue) return
+
+              setValue(getFieldName("seconds"), maskNumber(e.target.value))
+            }}
             describedBy={`${id}-error`}
             disabled={disabled}
             dataTestId={dataTestId ? `${dataTestId}-seconds` : undefined}
@@ -164,8 +182,8 @@ const TimeField = ({
         )}
 
         <Select
-          name={fieldName("period")}
-          id={fieldName("period")}
+          name={getFieldName("period")}
+          id={getFieldName("period")}
           labelClassName="sr-only"
           label={strings?.time ?? t("t.time")}
           register={register}


### PR DESCRIPTION
[Doorway #771](https://github.com/metrotranscom/doorway/issues/771)

## Description

This provides the same input masking for Time fields as Date fields (only numbers are allowed).

## How Can This Be Tested/Reviewed?

Storybook: https://deploy-preview-158--storybook-bloom-dev.netlify.app/?path=/story/forms-time-field--default

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
