### PR TITLE
feat: add ListingGroup props 

### DIFF
--- a/src/page_components/listing/ListingsGroup.tsx
+++ b/src/page_components/listing/ListingsGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { Button } from "../../actions/Button"
 import { Icon, UniversalIconType } from "../../icons/Icon"
 import "./ListingsGroup.scss"
@@ -13,6 +13,7 @@ export interface ListingsGroupProps {
   showButtonText: string
   refKey?: string
   observerRef?: React.MutableRefObject<null | IntersectionObserver>
+  isOpen?: boolean
 }
 
 const ListingsGroup = (props: ListingsGroupProps) => {
@@ -20,6 +21,12 @@ const ListingsGroup = (props: ListingsGroupProps) => {
   const toggleListings = () => setShowListings(!showListings)
 
   const listingsCount = ` (${props.listingsCount})`
+
+  useEffect(() => {
+    if (props.isOpen) {
+      setShowListings(true)
+    }
+  }, [props.isOpen])
 
   return (
     <div className="listings-group">


### PR DESCRIPTION
# Pull Request Template

This PR addresses [DAH-3109](https://sfgovdt.jira.com/browse/DAH-3109) to add props refKey?, observerRef?, and isOpen? to allow for customization of a new DAHLIA navigation component. 

## Description

Adds props refKey?, observerRef?, and isOpen? to the ListingGroup component.
 
## How Can This Be Tested/Reviewed?

There are no functionality/visual changes, ensure no regressions. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [x] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
