### PR TITLE
fix: SiteHeader keyboard accessibility

### DIFF
--- a/src/headers/SiteHeader.tsx
+++ b/src/headers/SiteHeader.tsx
@@ -114,7 +114,11 @@ const SiteHeader = (props: SiteHeaderProps) => {
       // Close menu when tabbing out backwards or forwards
       if (
         (event.shiftKey && event.key === "Tab" && isDesktop && index === 0 && parentMenu) ||
-        (event.key === "Tab" && isDesktop && index === options.length - 1 && parentMenu)
+        (event.key === "Tab" &&
+          !event.shiftKey &&
+          isDesktop &&
+          index === options.length - 1 &&
+          parentMenu)
       ) {
         setActiveMenu(null)
       }


### PR DESCRIPTION
# Pull Request Template

[DAH-2757 ](https://sfgovdt.jira.com/browse/DAH-2757)

## Description

Fixes a keyboard accessibility bug for the SiteHeader component where users could not shift+tab on the last element on the menu.

## How Can This Be Tested/Reviewed?

Confirm that you can tab and shift+tab through the SiteHeader.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
