### PR TITLE
fix: replace deprecated ReactChild with ReactNode

### DIFF
--- a/src/overlays/LoadingOverlay.tsx
+++ b/src/overlays/LoadingOverlay.tsx
@@ -4,7 +4,7 @@ import "./LoadingOverlay.scss"
 
 type LoadingOverlayProps = {
   isLoading: boolean
-  children: React.ReactChild
+  children: React.ReactNode
 }
 
 const LoadingOverlay = ({ isLoading, children }: LoadingOverlayProps) => {


### PR DESCRIPTION
# Pull Request Template

#issue
https://github.com/bloom-housing/ui-components/issues/165#issue-2973361067

## Description

Replace deprecated ReactChild with ReactNode 

## How Can This Be Tested/Reviewed?

This causes an "Type 'Element' is not assignable to type 'string'" error with ReactChild, which is resolved by updating to ReactNode.

```
const Foo = () => {
    return <div>foo</div>
}

<LoadingOverlay isLoading={loading}>
    <Foo />
    <Foo />
</LoadingOverlay>
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
