### PR TITLE
fix: custom blur + focus support

### DIFF
--- a/src/forms/Field.tsx
+++ b/src/forms/Field.tsx
@@ -87,10 +87,28 @@ const Field = (props: FieldProps) => {
 
   let inputProps = { ...props.inputProps }
   if (props.type === "currency") {
+    const customOnBlur =
+      typeof inputProps.onBlur === "function"
+        ? (inputProps.onBlur as () => void)
+        : () => {
+            //noop
+          }
+    const customOnFocus =
+      typeof inputProps.onFocus === "function"
+        ? (inputProps.onFocus as () => void)
+        : () => {
+            //noop
+          }
     inputProps = {
       ...inputProps,
-      onBlur: () => formatValue(),
-      onFocus: () => formatValue(true),
+      onBlur: () => {
+        formatValue()
+        customOnBlur()
+      },
+      onFocus: () => {
+        formatValue(true)
+        customOnFocus()
+      },
       onChange: filterNumbers,
     }
   }


### PR DESCRIPTION
# Pull Request Template

#167

## Description

This PR builds custom onBlur and onFocus support for the currency field type to support validation. Given that inputProps are passed in as unknown, I had to do some wacky typescript stuff to make things work. Open to feedback here but this is the simplest approach that functioned without errors.

## How Can This Be Tested/Reviewed?

This can be tested by adding the following line to the currency field story: 
`inputProps={{ onBlur: () => console.log("please") }}`

A note that console logging is sort of inconsistent in story book and you may need to open a close the console in between clicking in and out of the field to see your "please"

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
