### PR TITLE
fix: field group a11y updates

### DIFF
--- a/src/forms/FieldGroup.tsx
+++ b/src/forms/FieldGroup.tsx
@@ -31,6 +31,7 @@ interface FieldGroupProps {
   fieldLabelClassName?: string
   fields?: FieldSingle[]
   groupLabel?: string | React.ReactNode
+  groupLabelClassName?: string
   groupNote?: string
   groupSubNote?: string
   name: string
@@ -47,6 +48,7 @@ interface FieldGroupProps {
 const FieldGroup = ({
   name,
   groupLabel,
+  groupLabelClassName,
   fields,
   type = "checkbox",
   validation = {},
@@ -75,9 +77,9 @@ const FieldGroup = ({
 
   const getIndividualInput = (item: FieldSingle): React.ReactNode => {
     return (
-      <div key={item.value}>
+      <>
         <input
-          aria-describedby={`${name}-error`}
+          aria-describedby={`${name}-error ${item.note ? `${item.id}-note` : ""}`}
           aria-invalid={!!error || false}
           type={type}
           id={item.id}
@@ -105,7 +107,11 @@ const FieldGroup = ({
         >
           {item.label}
         </label>
-        {item.note && <span className={"field-note font-normal"}>{item.note}</span>}
+        {item.note && (
+          <span id={`${item.id}-note`} className={"field-note font-normal"}>
+            {item.note}
+          </span>
+        )}
 
         {item.description && (
           <div className="ml-8 -mt-1 mb-5">
@@ -119,7 +125,7 @@ const FieldGroup = ({
             </ExpandableContent>
           </div>
         )}
-      </div>
+      </>
     )
   }
 
@@ -145,7 +151,7 @@ const FieldGroup = ({
 
   const getInputSet = (item: FieldSingle): React.ReactNode => {
     return (
-      <div key={item.value}>
+      <>
         {getIndividualInput(item)}
         {item.additionalText && checkedInputs.indexOf(item.label?.toString() || "") >= 0 && (
           <Field
@@ -160,17 +166,21 @@ const FieldGroup = ({
             dataTestId={item.dataTestId}
           />
         )}
-      </div>
+      </>
     )
   }
+  const describedBy = [groupSubNote ? `${name}-group-sub-note` : "", error ? `${name}-error` : ""]
+    .filter(Boolean)
+    .join(" ")
+
   return (
-    <fieldset
-      aria-describedby={`${groupSubNote ? `${name}-group-sub-note` : ""} ${
-        error ? `${name}-error` : ""
-      }`}
-    >
+    <fieldset {...(describedBy ? { "aria-describedby": describedBy } : {})}>
       {groupLabel && (
-        <legend className={`text__caps-spaced ${error ? "text-alert" : ""}`}>{groupLabel}</legend>
+        <legend
+          className={`text__caps-spaced ${error ? "text-alert" : ""} ${groupLabelClassName || ""}`}
+        >
+          {groupLabel}
+        </legend>
       )}
       {groupNote && <p className="field-note mb-4">{groupNote}</p>}
 


### PR DESCRIPTION
## Description

Accessibility and miscellaneous improvements to the FieldGroup component


* Removes duplicate keys
* Associates notes with inputs
* Prevents adding an aria-describedby with a blank as this can cause issues with VoiceOver
* Allows for a class name on groupLabel

## How Can This Be Tested/Reviewed?

There is no new functionality, so we must ensure there are no regressions. Here is the deployed [Storybook](https://deploy-preview-202--storybook-bloom-dev.netlify.app/?path=/docs/forms-fieldgroup--docs).

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have made any corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated stories if new changes are not captured in Storybook
- [x] New and existing unit tests pass locally with my changes
- [ ] I have exported any new pieces added to ui-components
- [ ] I have documented this change in the changelog, and any breaking changes are well described

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Either review the Storybook preview or pull the changes down locally and test that the acceptance criteria is met
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

On merge, squash commits.
